### PR TITLE
Add (fork) fork of CSL to build environment

### DIFF
--- a/node-packages.nix
+++ b/node-packages.nix
@@ -31,6 +31,24 @@ let
         sha512 = "46ts2s0W63nzqHMhaXKACeY0GDWdnPet9wqOWtb8X3Y5LzokcaDKupLO2eHUwlvQyFzD9gxJlWPi/LqZPkn4oQ==";
       };
     };
+    "@ngua/cardano-serialization-lib-browser-9.1.2" = {
+      name = "_at_ngua_slash_cardano-serialization-lib-browser";
+      packageName = "@ngua/cardano-serialization-lib-browser";
+      version = "9.1.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@ngua/cardano-serialization-lib-browser/-/cardano-serialization-lib-browser-9.1.2.tgz";
+        sha512 = "0KkS3vCwrK8Yxs+yuoFJ05Ou5r0AZJNTWks9otP5h9ODsTUpkgJDb3lVmflJmSB0KnA9JvF3AmcN/swXj/yw+A==";
+      };
+    };
+    "@ngua/cardano-serialization-lib-nodejs-9.1.2" = {
+      name = "_at_ngua_slash_cardano-serialization-lib-nodejs";
+      packageName = "@ngua/cardano-serialization-lib-nodejs";
+      version = "9.1.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@ngua/cardano-serialization-lib-nodejs/-/cardano-serialization-lib-nodejs-9.1.2.tgz";
+        sha512 = "6xpp5Xjcqm9eHIrKBUmmIeZV6n0OeK6t8vCyQzF8KcHEQiknAcIcoIq/wf7sEcLV3ohwn945QCKkM3rKsKF5FA==";
+      };
+    };
     "@types/json-bigint-1.0.1" = {
       name = "_at_types_slash_json-bigint";
       packageName = "@types/json-bigint";
@@ -189,6 +207,8 @@ let
           sources."ws-7.5.6"
         ];
       })
+      sources."@ngua/cardano-serialization-lib-browser-9.1.2"
+      sources."@ngua/cardano-serialization-lib-nodejs-9.1.2"
       sources."big-integer-1.6.51"
       (sources."bufferutil-4.0.5" // {
         dependencies = [

--- a/package-lock.json
+++ b/package-lock.json
@@ -91,6 +91,16 @@
         }
       }
     },
+    "@ngua/cardano-serialization-lib-browser": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/@ngua/cardano-serialization-lib-browser/-/cardano-serialization-lib-browser-9.1.2.tgz",
+      "integrity": "sha512-0KkS3vCwrK8Yxs+yuoFJ05Ou5r0AZJNTWks9otP5h9ODsTUpkgJDb3lVmflJmSB0KnA9JvF3AmcN/swXj/yw+A=="
+    },
+    "@ngua/cardano-serialization-lib-nodejs": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/@ngua/cardano-serialization-lib-nodejs/-/cardano-serialization-lib-nodejs-9.1.2.tgz",
+      "integrity": "sha512-6xpp5Xjcqm9eHIrKBUmmIeZV6n0OeK6t8vCyQzF8KcHEQiknAcIcoIq/wf7sEcLV3ohwn945QCKkM3rKsKF5FA=="
+    },
     "big-integer": {
       "version": "1.6.51",
       "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
   "license": "ISC",
   "dependencies": {
     "@cardano-ogmios/client": "^4.2.1",
+    "@ngua/cardano-serialization-lib-nodejs": "^9.1.2",
+    "@ngua/cardano-serialization-lib-browser": "^9.1.2",
     "big-integer": "^1.6.51",
     "bufferutil": "^4.0.5",
     "uniqid": "^5.4.0",


### PR DESCRIPTION
Closes #45 

This will add a fork of Sundae's `cardano-serialization-lib` fork to the `node_modules` in our project