### PR TITLE
Further improvements on Value safety constructors.

### DIFF
--- a/src/Deserialization/UnspentOutput.purs
+++ b/src/Deserialization/UnspentOutput.purs
@@ -73,7 +73,9 @@ convertValue value = do
         )
     -- convert BigNum values, possibly failing
     traverse (traverse convertBigNum) multiasset''
-  T.mkValue (T.Coin coin) <$> T.mkNonAdaAsset (fromMaybe Map.empty multiasset)
+  pure
+    $ T.mkValue (T.Coin coin)
+    $ T.mkNonAdaAsset (fromMaybe Map.empty multiasset)
 
 foreign import getInput :: TransactionUnspentOutput -> TransactionInput
 foreign import getOutput :: TransactionUnspentOutput -> TransactionOutput

--- a/src/Types/Value.purs
+++ b/src/Types/Value.purs
@@ -233,8 +233,6 @@ mkNonAdaAssets'
 mkNonAdaAssets' =
   traverse (bitraverse mkCurrencySymbol mkTokenNames) >>> map Map.fromFoldable
 
--- Don't need mkNonAdaAsset here, we could just use Data Constructor since
--- mkCurrencySymbol is called inside mkNonAdaAssets' which should be safe.
 -- | Given a Traversable of ByteArrays and amounts to safely convert into a
 -- | NonAdaAsset
 mkNonAdaAssets

--- a/src/Types/Value.purs
+++ b/src/Types/Value.purs
@@ -131,7 +131,7 @@ mkCurrencySymbol byteArr =
 -- Do not export. Create an Ada CurrencySymbol from a ByteArray
 mkUnsafeAdaSymbol :: ByteArray -> Maybe CurrencySymbol
 mkUnsafeAdaSymbol byteArr =
-  if byteLength byteArr == 0 then pure unsafeAdaSymbol else Nothing
+  if byteArr == mempty then pure unsafeAdaSymbol else Nothing
 
 --------------------------------------------------------------------------------
 -- TokenName
@@ -172,7 +172,7 @@ mkTokenNames = traverse (ltraverse mkTokenName) >>> map Map.fromFoldable
 -- Do not export. Create an Ada TokenName from a ByteArray
 mkUnsafeTokenSymbol :: ByteArray -> Maybe TokenName
 mkUnsafeTokenSymbol byteArr =
-  if byteLength byteArr == 0 then pure unsafeAdaToken else Nothing
+  if byteArr == mempty then pure unsafeAdaToken else Nothing
 
 --------------------------------------------------------------------------------
 -- NonAdaAsset
@@ -548,4 +548,4 @@ sumTokenNameLengths = foldl lenAdd zero <<< unsafeAllTokenNames
 -- From https://github.com/mlabs-haskell/bot-plutus-interface/blob/master/src/BotPlutusInterface/PreBalance.hs
 -- | Filter a value to contain only non Ada assets
 filterNonAda :: Value -> Value
-filterNonAda (Value coins _) = Value coins mempty
+filterNonAda (Value coins _) = Value coins mempty   


### PR DESCRIPTION
- I think it's safe to make `NonAdaAsset` since `CurrencySymbol` and `TokenName` are safe by construction.
- Therefore, I've added a `Newtype` instance for the `NonAdaAsset`.
- General improvements to some of the helpers, especially `mkSingletonValue` to cover more cases.