### PR TITLE
Example `Transaction` built with `QueryM`

### DIFF
--- a/examples/index.js
+++ b/examples/index.js
@@ -1,7 +1,7 @@
 "use strict";
 
 // This needs to be asynchronous to load the WASM from CSL
-import("./nami/Simple.purs").then((m) => m.main());
+import("./nami/Pkh2Pkh.purs").then((m) => m.main());
 
 if (module.hot) {
   module.hot.accept();

--- a/examples/nami/BuildTransaction.purs
+++ b/examples/nami/BuildTransaction.purs
@@ -1,0 +1,37 @@
+module Examples.Nami.BuildTransaction (main) where
+
+import Prelude
+
+import BalanceTx (UnbalancedTransaction)
+import Control.Monad.Error.Class (throwError)
+import Control.Monad.Reader (runReaderT)
+import Data.Maybe (Maybe(..), maybe)
+import Effect (Effect)
+import Effect.Aff (error, launchAff_)
+import Effect.Aff.Class (liftAff)
+import QueryM (QueryM, defaultServerConfig, getWalletAddress)
+import Undefined (undefined)
+import Wallet (mkNamiWalletAff)
+
+main :: Effect Unit
+main = launchAff_ $ do
+  wallet <- Just <$> mkNamiWalletAff
+  tx <- runReaderT
+    buildTransaction
+    { ws: {-TODO-}  undefined
+    , wallet
+    , serverConfig: defaultServerConfig
+    }
+  undefined
+
+buildTransaction :: QueryM UnbalancedTransaction
+buildTransaction = do
+  ownAddress <-
+    maybe
+      (throw "Failed to get wallet address")
+      pure
+      =<< getWalletAddress
+  undefined
+
+throw :: forall (a :: Type). String -> QueryM a
+throw = liftAff <<< throwError <<< error

--- a/examples/nami/Pkh2Pkh.purs
+++ b/examples/nami/Pkh2Pkh.purs
@@ -41,9 +41,10 @@ import Wallet (mkNamiWalletAff)
 main :: Effect Unit
 main = launchAff_ $ do
   wallet <- Just <$> mkNamiWalletAff
+  ws <- mkOgmiosWebSocketAff "ws:127.0.0.1:1337"
   tx <- runReaderT
     buildTransaction
-    { ws: {-TODO-}  undefined
+    { ws
     , wallet
     , serverConfig: defaultServerConfig
     }

--- a/examples/nami/Pkh2Pkh.purs
+++ b/examples/nami/Pkh2Pkh.purs
@@ -24,7 +24,7 @@ main = launchAff_ $ do
     }
   undefined
 
-buildTransaction :: QueryM UnbalancedTransaction
+buildTransaction :: QueryM UnbalancedTx
 buildTransaction = do
   ownAddress <-
     maybe

--- a/examples/nami/Pkh2Pkh.purs
+++ b/examples/nami/Pkh2Pkh.purs
@@ -2,14 +2,33 @@ module Examples.Nami.Pkh2Pkh (main) where
 
 import Prelude
 
-import BalanceTx (UnbalancedTransaction)
 import Control.Monad.Error.Class (throwError)
 import Control.Monad.Reader (runReaderT)
+import Data.Array as Array
+import Data.BigInt as BigInt
+import Data.Map as Map
 import Data.Maybe (Maybe(..), maybe)
+import Data.Newtype (unwrap)
+import Data.Tuple (fst)
 import Effect (Effect)
 import Effect.Aff (error, launchAff_)
 import Effect.Aff.Class (liftAff)
-import QueryM (QueryM, defaultServerConfig, getWalletAddress)
+import QueryM (QueryM, defaultServerConfig, getWalletAddress, utxosAt)
+import Types.POSIXTimeRange
+  ( Extended(..)
+  , Interval(..)
+  , LowerBound(..)
+  , UpperBound(..)
+  )
+import Types.Transaction
+  ( NetworkId(..)
+  , Transaction(..)
+  , TransactionOutput(..)
+  , TxBody(..)
+  , emptyTransactionWitnessSet
+  )
+import Types.UnbalancedTransaction (UnbalancedTx(..))
+import Types.Value as Value
 import Undefined (undefined)
 import Wallet (mkNamiWalletAff)
 
@@ -24,14 +43,55 @@ main = launchAff_ $ do
     }
   undefined
 
-buildTransaction :: QueryM UnbalancedTx
-buildTransaction = do
-  ownAddress <-
-    maybe
-      (throw "Failed to get wallet address")
-      pure
-      =<< getWalletAddress
-  undefined
+buildTransaction :: QueryM Transaction
+buildTransaction = undefined
+
+buildUnbalancedTransaction :: QueryM UnbalancedTx
+buildUnbalancedTransaction = do
+  ownAddress <- mthrow "Failed to get wallet address" getWalletAddress
+  inputs <-
+    map fst
+      <<< Map.toUnfoldable
+      <<< unwrap
+      <$> mthrow "Failed to get own utxos" (utxosAt ownAddress)
+  pure $ UnbalancedTx
+    { transaction: Transaction
+        { body: TxBody
+            { inputs
+            , outputs: Array.singleton $ TransactionOutput
+                { address: ownAddress
+                , amount: Value.lovelaceValueOf $ BigInt.fromInt 2000000
+                , data_hash: Nothing
+                }
+            -- FIXME
+            , fee: undefined
+            , network_id: Just Testnet
+            , certs: Nothing
+            , collateral: Nothing
+            , auxiliary_data_hash: Nothing
+            , mint: Nothing
+            , required_signers: Nothing
+            , script_data_hash: Nothing
+            , ttl: Nothing
+            , update: Nothing
+            , validity_start_interval: Nothing
+            , withdrawals: Nothing
+            }
+        , is_valid: true
+        , witness_set: emptyTransactionWitnessSet
+        , auxiliary_data: Nothing
+        }
+    , requiredSignatories: Map.empty
+    , utxoIndex: Map.empty
+    , validityTimeRange: Interval
+        { from: LowerBound NegInf true
+        , to: UpperBound PosInf true
+        }
+    }
 
 throw :: forall (a :: Type). String -> QueryM a
 throw = liftAff <<< throwError <<< error
+
+mthrow :: forall (a :: Type). String -> QueryM (Maybe a) -> QueryM a
+mthrow msg act = maybe (throw msg) pure =<< act
+

--- a/examples/nami/Pkh2Pkh.purs
+++ b/examples/nami/Pkh2Pkh.purs
@@ -1,4 +1,4 @@
-module Examples.Nami.BuildTransaction (main) where
+module Examples.Nami.Pkh2Pkh (main) where
 
 import Prelude
 

--- a/examples/nami/Pkh2Pkh.purs
+++ b/examples/nami/Pkh2Pkh.purs
@@ -1,3 +1,36 @@
+--
+-- This module demonstrates how the `QueryM` interface can be used to build a
+-- transaction from scratch. It creates and balances an example transaction that
+-- gets UTxOs from the user's wallet and sends two Ada back to the same wallet
+-- address
+--
+-- * Prerequisites
+--   - A Chromium-based browser
+--
+--   - A Nami wallet funded with test Ada ("tAda") and collateral set, If you need
+--     tAda, visit https://testnets.cardano.org/en/testnets/cardano/tools/faucet/
+--
+-- * How to run
+--
+--   The `QueryM` interface requires several external services to be running. From
+--   the repository root, run the following commands:
+--
+--   - `make run-tesnet-node`
+--      Starts a testnet Cardano node. May take some time to sync fully
+--
+--   - `make run-tesnet-ogmios`
+--      Starts the Ogmios service. Also needs to sync with the running node
+--
+--   - `make run-haskell-server`
+--      Starts the external Haskell server that will perform the transaction
+--      fee calculations (no sync required)
+--
+--   Once these services are *fully synced*, run:
+--
+--   - `npm run dev` and visit `localhost:4008`. You may be prompted to enable
+--     access to your wallet if you have not run this example before. You will
+--     also be prompted to sign the transaction using your Nami password
+
 module Examples.Nami.Pkh2Pkh (main) where
 
 import Prelude

--- a/examples/nami/Pkh2Pkh.purs
+++ b/examples/nami/Pkh2Pkh.purs
@@ -85,7 +85,7 @@ buildUnbalancedTransaction = do
                 , data_hash: Nothing
                 }
             -- FIXME
-            , fee: undefined
+            , fee: Value.mkCoin 0
             , network_id: Just Testnet
             , certs: Nothing
             , collateral: Nothing

--- a/examples/nami/Pkh2Pkh.purs
+++ b/examples/nami/Pkh2Pkh.purs
@@ -15,10 +15,10 @@
 --   The `QueryM` interface requires several external services to be running. From
 --   the repository root, run the following commands:
 --
---   - `make run-tesnet-node`
+--   - `make run-testnet-node`
 --      Starts a testnet Cardano node. May take some time to sync fully
 --
---   - `make run-tesnet-ogmios`
+--   - `make run-testnet-ogmios`
 --      Starts the Ogmios service. Also needs to sync with the running node
 --
 --   - `make run-haskell-server`

--- a/examples/nami/Pkh2Pkh.purs
+++ b/examples/nami/Pkh2Pkh.purs
@@ -7,27 +7,33 @@ import Control.Monad.Reader (runReaderT)
 import Data.Array as Array
 import Data.BigInt as BigInt
 import Data.Map as Map
-import Data.Maybe (Maybe(..), maybe)
+import Data.Maybe (Maybe(Just, Nothing), maybe)
 import Data.Newtype (unwrap)
 import Data.Tuple (fst)
 import Effect (Effect)
 import Effect.Aff (error, launchAff_)
 import Effect.Aff.Class (liftAff)
-import QueryM (QueryM, defaultServerConfig, getWalletAddress, utxosAt)
+import QueryM
+  ( QueryM
+  , defaultServerConfig
+  , getWalletAddress
+  , mkOgmiosWebSocketAff
+  , utxosAt
+  )
 import Types.POSIXTimeRange
-  ( Extended(..)
-  , Interval(..)
-  , LowerBound(..)
-  , UpperBound(..)
+  ( Extended(NegInf, PosInf)
+  , Interval(Interval)
+  , LowerBound(LowerBound)
+  , UpperBound(UpperBound)
   )
 import Types.Transaction
-  ( NetworkId(..)
-  , Transaction(..)
-  , TransactionOutput(..)
-  , TxBody(..)
+  ( NetworkId(Testnet)
+  , Transaction(Transaction)
+  , TransactionOutput(TransactionOutput)
+  , TxBody(TxBody)
   , emptyTransactionWitnessSet
   )
-import Types.UnbalancedTransaction (UnbalancedTx(..))
+import Types.UnbalancedTransaction (UnbalancedTx(UnbalancedTx))
 import Types.Value as Value
 import Undefined (undefined)
 import Wallet (mkNamiWalletAff)

--- a/examples/nami/Pkh2Pkh.purs
+++ b/examples/nami/Pkh2Pkh.purs
@@ -13,6 +13,7 @@ import Data.Maybe (Maybe(Just, Nothing), maybe)
 import Data.Newtype (unwrap)
 import Data.Tuple (fst)
 import Effect (Effect)
+import Effect.Class (liftEffect)
 import Effect.Aff (error, launchAff_)
 import Effect.Aff.Class (liftAff)
 import Effect.Console as Console
@@ -23,6 +24,8 @@ import QueryM
   , mkOgmiosWebSocketAff
   , utxosAt
   )
+import Serialization as Serialization
+import Types.ByteArray (byteArrayToHex)
 import Types.POSIXTimeRange
   ( Extended(NegInf, PosInf)
   , Interval(Interval)
@@ -39,6 +42,7 @@ import Types.Transaction
 import Types.UnbalancedTransaction (UnbalancedTx(UnbalancedTx))
 import Types.Value as Value
 import Undefined (undefined)
+import Untagged.Union (asOneOf)
 import Wallet (mkNamiWalletAff)
 
 main :: Effect Unit
@@ -51,7 +55,12 @@ main = launchAff_ $ do
     , wallet
     , serverConfig: defaultServerConfig
     }
-  undefined
+  liftEffect $
+    Console.log
+      <<< byteArrayToHex
+      <<< Serialization.toBytes
+      <<< asOneOf
+      =<< Serialization.convertTransaction tx
 
 buildTransaction :: QueryM Transaction
 buildTransaction = either (throw <<< show) pure

--- a/examples/nami/Pkh2Pkh.purs
+++ b/examples/nami/Pkh2Pkh.purs
@@ -41,7 +41,6 @@ import Types.Transaction
   )
 import Types.UnbalancedTransaction (UnbalancedTx(UnbalancedTx))
 import Types.Value as Value
-import Undefined (undefined)
 import Untagged.Union (asOneOf)
 import Wallet (mkNamiWalletAff)
 
@@ -84,7 +83,7 @@ buildUnbalancedTransaction = do
                 , amount: Value.lovelaceValueOf $ BigInt.fromInt 2000000
                 , data_hash: Nothing
                 }
-            -- FIXME
+            -- ??
             , fee: Value.mkCoin 0
             , network_id: Just Testnet
             , certs: Nothing
@@ -115,4 +114,3 @@ throw = liftAff <<< throwError <<< error
 
 mthrow :: forall (a :: Type). String -> QueryM (Maybe a) -> QueryM a
 mthrow msg act = maybe (throw msg) pure =<< act
-

--- a/src/Types/Transaction.purs
+++ b/src/Types/Transaction.purs
@@ -216,12 +216,12 @@ instance Show TransactionWitnessSet where
 
 emptyTransactionWitnessSet :: TransactionWitnessSet
 emptyTransactionWitnessSet = TransactionWitnessSet
-  { vkeys : Nothing
-  , native_scripts : Nothing
-  , bootstraps : Nothing
-  , plutus_scripts : Nothing
-  , plutus_data : Nothing
-  , redeemers : Nothing
+  { vkeys: Nothing
+  , native_scripts: Nothing
+  , bootstraps: Nothing
+  , plutus_scripts: Nothing
+  , plutus_data: Nothing
+  , redeemers: Nothing
   }
 
 type BootstrapWitness =

--- a/src/Types/Transaction.purs
+++ b/src/Types/Transaction.purs
@@ -6,7 +6,7 @@ import Data.BigInt (BigInt)
 import Data.Generic.Rep (class Generic)
 import Data.HashMap (HashMap)
 import Data.Map (Map)
-import Data.Maybe (Maybe)
+import Data.Maybe (Maybe(Nothing))
 import Data.Newtype (class Newtype)
 import Data.Rational (Rational)
 import Data.Show.Generic (genericShow)
@@ -213,6 +213,16 @@ derive newtype instance Eq TransactionWitnessSet
 
 instance Show TransactionWitnessSet where
   show = genericShow
+
+emptyTransactionWitnessSet :: TransactionWitnessSet
+emptyTransactionWitnessSet = TransactionWitnessSet
+  { vkeys : Nothing
+  , native_scripts : Nothing
+  , bootstraps : Nothing
+  , plutus_scripts : Nothing
+  , plutus_data : Nothing
+  , redeemers : Nothing
+  }
 
 type BootstrapWitness =
   { vkey :: Vkey


### PR DESCRIPTION
Closes #63. This just builds a `Transaction` through the `QueryM` interface. Running it locally gets as far as balancing

I've changed `examples/index.js` to run this example instead of the older one. We should figure out #100 in order to enable different entry points to be run

There's a placeholder fee of 0 Ada. In the Plutus definition of `Tx`, the fee is a `Value` and this gets set to `mempty` when the transaction first gets built. I'll open an issue about this so we can address it later