### PR TITLE
Fix `Value` helper and balancer to build transaction

### DIFF
--- a/src/BalanceTx.purs
+++ b/src/BalanceTx.purs
@@ -22,7 +22,7 @@ import Data.Array ((\\), findIndex, modifyAt)
 import Data.Array as Array
 import Data.Bifunctor (lmap, rmap)
 import Data.BigInt (BigInt, fromInt, quot)
-import Data.Either (Either(Left, Right), either, hush, note)
+import Data.Either (Either(Left, Right), hush, note)
 import Data.Foldable as Foldable
 import Data.Generic.Rep (class Generic)
 import Data.List ((:), List(Nil), partition)
@@ -32,6 +32,7 @@ import Data.Newtype (class Newtype, unwrap, wrap)
 import Data.Show.Generic (genericShow)
 import Data.Tuple (fst)
 import Data.Tuple.Nested ((/\), type (/\))
+-- import Debug (spy)
 import Effect.Class (liftEffect)
 import ProtocolParametersAlonzo
   ( adaOnlyWords
@@ -266,41 +267,51 @@ balanceTxM (UnbalancedTx { transaction: unbalancedTx, utxoIndex }) = do
             -- add collateral to this for now.
             allUtxos :: Utxo
             allUtxos = utxos `Map.union` utxoIndex''
-          -- Add hardcoded Nami 5 Ada and sign before instead of recursively
-          -- signing in loop. Could refactor this part into a separate function.
-          signedUnbalancedTx <-
-            signTransaction (addTxCollateral unbalancedTx collateral)
-              <#> note (SignTxError' $ CouldNotSignTx ownAddr)
-          case signedUnbalancedTx of
+
+            -- After adding collateral, we need to balance the inputs and
+            -- non-Ada outputs before looping, i.e. we need to add input fees
+            -- for the Ada only collateral. No MinUtxos required. In fact perhaps
+            -- this step can be skipped and we can go straight to prebalancer.
+            unbalancedCollTx = addTxCollateral unbalancedTx collateral
+          -- Prebalance tx without fees:
+          case prebalanceCollateral zero allUtxos ownAddr unbalancedCollTx of
             Left err -> pure $ Left err
-            Right sUbTx ->
-              -- After adding collateral, we need to balance the inputs and
-              -- non-Ada outputs before looping, i.e. we need to add input fees
-              -- for the Ada only collateral. No MinUtxos required:
-              -- Alternatively add this functionality back to preBalanceTxBody
-              -- and only call collateral adder initially.
-              -- Balance tx without fees:
-              case prebalanceCollateral zero allUtxos ownAddr sUbTx of
+            Right ubcTx' -> do
+              fees' <- lmap CalculateMinFeeError' <$> calculateMinFee' ubcTx'
+              -- Prebalance tx with fees:
+              let
+                unbalancedCollTx' = fees' >>= \fees ->
+                  prebalanceCollateral
+                    (fees + feeBuffer)
+                    allUtxos
+                    ownAddr
+                    ubcTx'
+              case unbalancedCollTx' of
                 Left err -> pure $ Left err
-                Right sUbTx' -> do
-                  fees' <- lmap CalculateMinFeeError' <$> calculateMinFee' sUbTx'
-                  -- Balance tx with fees:
-                  let
-                    signedCollUnbalancedTx' = fees' >>= \fees ->
-                      prebalanceCollateral
-                        (fees + feeBuffer)
-                        allUtxos
-                        ownAddr
-                        sUbTx'
-                  case signedCollUnbalancedTx' of
+                Right unbalancedCollTx'' ->
+                  loop allUtxos ownAddr [] unbalancedCollTx'' >>= case _ of
                     Left err -> pure $ Left err
-                    Right signedCollUnbalancedTx ->
-                      loop allUtxos ownAddr [] signedCollUnbalancedTx >>=
-                        either
-                          (Left >>> pure)
-                          ( returnAdaChange ownAddr allUtxos
-                              >>> map (lmap ReturnAdaChangeError')
-                          )
+                    Right nonAdaBalancedCollTx ->
+                      lmap ReturnAdaChangeError' <$>
+                        returnAdaChange ownAddr allUtxos nonAdaBalancedCollTx
+                        >>= case _ of
+                          Left err -> pure $ Left err
+                          Right unsignedTx ->
+                            signTransaction unsignedTx
+                              <#> note (SignTxError' $ CouldNotSignTx ownAddr)
+
+  -- Some useful spies for debugging.
+  -- case signedTx' of
+  --   Left err -> pure $ Left err
+  --   Right signedTx -> do
+  --     let signedTxBody = (unwrap signedTx).body
+  --         signedTxOuputs = (unwrap signedTxBody).outputs
+  --         x = spy "signedTxInputVal" (getInputValue allUtxos signedTxBody)
+  --         y = spy "signedTxOutputs" signedTxOuputs
+  --         z = spy "signedTxOutputsVal" (Array.foldMap getAmount signedTxOuputs)
+  --         a = spy "signedTxFees" $ (unwrap signedTxBody).fee
+  --     pure $ pure $ signedTx
+
   where
   prebalanceCollateral
     :: BigInt
@@ -523,13 +534,13 @@ returnAdaChange changeAddr utxos (Transaction tx@{ body: TxBody txBody }) =
                           $ modifyAt
                               0
                               ( \(TransactionOutput o) -> TransactionOutput
-                                  o { amount = lovelaceValueOf returnAda }
+                                  o { amount = lovelaceValueOf returnAda' }
                               )
                           $ _.outputs <<< unwrap
                           $ txBody'
                       pure $
                         wrap
-                          tx { body = wrap txBody { outputs = newOutputs, fee = wrap fees } }
+                          tx { body = wrap txBody { outputs = newOutputs, fee = wrap fees' } }
                     else
                       Left $
                         ReturnAdaChangeError
@@ -674,9 +685,17 @@ balanceTxIns' utxos fees (TxBody txBody) = do
   nonMintedValue <- note (BalanceTxInsCannotMinus $ CannotMinus $ wrap mintVal)
     $ Array.foldMap getAmount txOutputs `minus` mintVal
 
+  -- Useful spies for debugging:
+  -- let x = spy "nonMintedVal" nonMintedValue
+  --     y = spy "feees" fees
+  --     z = spy "changeMinUtxo" changeMinUtxo
+  --     a = spy "txBody" txBody
+
   let
     minSpending :: Value
     minSpending = lovelaceValueOf (fees + changeMinUtxo) <> nonMintedValue
+
+  -- a = spy "minSpending" minSpending
 
   txIns :: Array TransactionInput <-
     lmap
@@ -716,6 +735,11 @@ collectTxIns originalTxIns utxos value =
       )
       originalTxIns
       $ utxosToTransactionInput utxos
+
+  -- Useful spies for debugging:
+  -- x = spy "collectTxInsValue" value
+  -- y = spy "txInsValueOG" (txInsValue originalTxIns)
+  -- z = spy "txInsValueNEW" (txInsValue updatedInputs)
 
   isSufficient :: Array TransactionInput -> Boolean
   isSufficient txIns' =
@@ -776,6 +800,11 @@ balanceNonAdaOuts' changeAddr utxos txBody'@(TxBody txBody) = do
     $ filterNonAda inputValue `minus` nonMintedAdaOutputValue
 
   let
+    -- Useful spies for debugging:
+    -- a = spy "balanceNonAdaOuts'nonMintedOutputValue" nonMintedOutputValue
+    -- b = spy "balanceNonAdaOuts'nonMintedAdaOutputValue" nonMintedAdaOutputValue
+    -- c = spy "balanceNonAdaOuts'nonAdaChange" nonAdaChange
+
     outputs :: Array TransactionOutput
     outputs =
       Array.fromFoldable $

--- a/src/Types/Value.purs
+++ b/src/Types/Value.purs
@@ -113,7 +113,7 @@ derive newtype instance eqCurrencySymbol :: Eq CurrencySymbol
 derive newtype instance ordCurrencySymbol :: Ord CurrencySymbol
 
 instance showCurrencySymbol :: Show CurrencySymbol where
-  show (CurrencySymbol cs) = show cs
+  show (CurrencySymbol cs) = "(CurrencySymbol" <> show cs <> ")"
 
 getCurrencySymbol :: CurrencySymbol -> ByteArray
 getCurrencySymbol (CurrencySymbol curSymbol) = curSymbol
@@ -143,7 +143,7 @@ derive newtype instance eqTokenName :: Eq TokenName
 derive newtype instance ordTokenName :: Ord TokenName
 
 instance showTokenName :: Show TokenName where
-  show (TokenName tn) = show tn
+  show (TokenName tn) = "(TokenName" <> show tn <> ")"
 
 getTokenName :: TokenName -> ByteArray
 getTokenName (TokenName tokenName) = tokenName
@@ -181,7 +181,7 @@ derive instance newtypeNonAdaAsset :: Newtype NonAdaAsset _
 derive newtype instance eqNonAdaAsset :: Eq NonAdaAsset
 
 instance showNonAdaAsset :: Show NonAdaAsset where
-  show (NonAdaAsset nonAdaAsset) = show nonAdaAsset
+  show (NonAdaAsset nonAdaAsset) = "(NonAdaAsset" <> show nonAdaAsset <> ")"
 
 instance semigroupNonAdaAsset :: Semigroup NonAdaAsset where
   append = unionWith (+)
@@ -539,4 +539,4 @@ sumTokenNameLengths = foldl lenAdd zero <<< unsafeAllTokenNames
 -- From https://github.com/mlabs-haskell/bot-plutus-interface/blob/master/src/BotPlutusInterface/PreBalance.hs
 -- | Filter a value to contain only non Ada assets
 filterNonAda :: Value -> Value
-filterNonAda (Value coins _) = Value coins mempty
+filterNonAda (Value _ nonAda) = Value mempty nonAda


### PR DESCRIPTION
- Balancer had issues which meant we weren't able to build a transaction - this is fixed due to a bug in `Value`.
- Balancer now signs at the very end.
- A few fixes in the post balancer to return Ada change.
- Refining `Show` instances in `Value`