### PR TITLE
Factor Wallet sum type out of `utxosAt`, tx logging and clean up `balanceTx` nesting

### DIFF
--- a/src/BalanceTx.purs
+++ b/src/BalanceTx.purs
@@ -380,7 +380,7 @@ balanceTxM (UnbalancedTx { transaction: unbalancedTx, utxoIndex }) =
   -- 1) A new utxo doesn't need to be created (no extra fees).
   -- 2) A new utxo needs to be created but the buffer provides enough Ada to
   -- create the utxo, cover any extra fees without a further need for looping.
-  -- This buffer could potentially be exactly calculated using (the Haskell server)
+  -- This buffer could potentially be calculated exactly using (the Haskell server)
   -- https://github.com/input-output-hk/plutus/blob/8abffd78abd48094cfc72f1ad7b81b61e760c4a0/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek/Internal.hs#L723
   -- The trade off for this set up is any transaction requires this buffer on
   -- top of their transaction as input.

--- a/src/BalanceTx.purs
+++ b/src/BalanceTx.purs
@@ -404,11 +404,12 @@ balanceTxM (UnbalancedTx { transaction: unbalancedTx, utxoIndex }) = do
   feeBuffer :: BigInt
   feeBuffer = fromInt 500000
 
+-- Logging for Transaction type
 logTx'
   :: forall m. MonadEffect m => String -> Utxo -> Transaction -> m Unit
 logTx' msg utxos (Transaction { body: body'@(TxBody body) }) =
   traverse_ (log <<< (<>) msg)
-    -- Add to this if you to log more
+    -- Add to log more:
     [ "Input Value: " <> show (getInputValue utxos body')
     , "Output Value: " <> show (Array.foldMap getAmount body.outputs)
     , "Fees: " <> show body.fee

--- a/src/BalanceTx.purs
+++ b/src/BalanceTx.purs
@@ -290,11 +290,11 @@ balanceTxM (UnbalancedTx { transaction: unbalancedTx, utxoIndex }) =
       returnAdaChange ownAddr allUtxos nonAdaBalancedCollTx <#>
         lmap ReturnAdaChangeError'
     -- Sign transaction:
-    signedTx <- ExceptT $
+    balancedTx <- ExceptT $
       signTransaction unsignedTx <#> note (SignTxError' $ CouldNotSignTx ownAddr)
 
     -- Logs final balanced tx and returns it
-    ExceptT $ logTx "Post-balancing Tx " allUtxos signedTx <#> Right
+    ExceptT $ logTx "Post-balancing Tx " allUtxos balancedTx <#> Right
   where
   prebalanceCollateral
     :: BigInt

--- a/src/BalanceTx.purs
+++ b/src/BalanceTx.purs
@@ -278,8 +278,8 @@ balanceTxM (UnbalancedTx { transaction: unbalancedTx, utxoIndex }) =
     -- Prebalance collaterised tx without fees:
     ubcTx <- except $
       prebalanceCollateral zero allUtxos ownAddr unbalancedCollTx
-    fees <- ExceptT $ calculateMinFee' ubcTx <#> lmap CalculateMinFeeError'
     -- Prebalance collaterised tx with fees:
+    fees <- ExceptT $ calculateMinFee' ubcTx <#> lmap CalculateMinFeeError'
     ubcTx' <- except $
       prebalanceCollateral (fees + feeBuffer) allUtxos ownAddr ubcTx
 

--- a/src/BalanceTx.purs
+++ b/src/BalanceTx.purs
@@ -271,6 +271,7 @@ balanceTxM (UnbalancedTx { transaction: unbalancedTx, utxoIndex }) =
       -- for the Ada only collateral. No MinUtxos required. In fact perhaps
       -- this step can be skipped and we can go straight to prebalancer.
       unbalancedCollTx = addTxCollateral unbalancedTx collateral
+
     -- Logging Unbalanced Tx with collateral added:
     logTx' "Unbalanced Collaterised Tx " allUtxos unbalancedCollTx
 
@@ -291,6 +292,7 @@ balanceTxM (UnbalancedTx { transaction: unbalancedTx, utxoIndex }) =
     -- Sign transaction:
     signedTx <- ExceptT $
       signTransaction unsignedTx <#> note (SignTxError' $ CouldNotSignTx ownAddr)
+
     -- Logs final balanced tx and returns it
     ExceptT $ logTx "Post-balancing Tx " allUtxos signedTx <#> Right
   where

--- a/src/BalanceTx.purs
+++ b/src/BalanceTx.purs
@@ -390,7 +390,7 @@ balanceTxM (UnbalancedTx { transaction: unbalancedTx, utxoIndex }) =
   feeBuffer :: BigInt
   feeBuffer = fromInt 500000
 
--- Logging for Transaction type
+-- Logging for Transaction type without returning Transaction
 logTx'
   :: forall (m :: Type -> Type)
    . MonadEffect m
@@ -406,6 +406,7 @@ logTx' msg utxos (Transaction { body: body'@(TxBody body) }) =
     , "Fees: " <> show body.fee
     ]
 
+-- Logging for Transaction type returning Transaction
 logTx
   :: forall (m :: Type -> Type)
    . MonadEffect m

--- a/src/BalanceTx.purs
+++ b/src/BalanceTx.purs
@@ -389,7 +389,12 @@ balanceTxM (UnbalancedTx { transaction: unbalancedTx, utxoIndex }) =
 
 -- Logging for Transaction type
 logTx'
-  :: forall m. MonadEffect m => String -> Utxo -> Transaction -> m Unit
+  :: forall (m :: Type -> Type)
+   . MonadEffect m
+  => String
+  -> Utxo
+  -> Transaction
+  -> m Unit
 logTx' msg utxos (Transaction { body: body'@(TxBody body) }) =
   traverse_ (log <<< (<>) msg)
     -- Add to log more:
@@ -399,7 +404,12 @@ logTx' msg utxos (Transaction { body: body'@(TxBody body) }) =
     ]
 
 logTx
-  :: forall m. MonadEffect m => String -> Utxo -> Transaction -> m Transaction
+  :: forall (m :: Type -> Type)
+   . MonadEffect m
+  => String
+  -> Utxo
+  -> Transaction
+  -> m Transaction
 logTx msg utxo tx = logTx' msg utxo tx *> pure tx
 
 -- Nami provides a 5 Ada collateral that we should add the tx before balancing

--- a/src/BalanceTx.purs
+++ b/src/BalanceTx.purs
@@ -270,6 +270,7 @@ balanceTxM (UnbalancedTx { transaction: unbalancedTx, utxoIndex }) =
       -- non-Ada outputs before looping, i.e. we need to add input fees
       -- for the Ada only collateral. No MinUtxos required. In fact perhaps
       -- this step can be skipped and we can go straight to prebalancer.
+      unbalancedCollTx :: Transaction
       unbalancedCollTx = addTxCollateral unbalancedTx collateral
 
     -- Logging Unbalanced Tx with collateral added:

--- a/src/QueryM.purs
+++ b/src/QueryM.purs
@@ -397,18 +397,33 @@ addressToOgmiosAddress = addressBech32
 -- Results may vary depending on Wallet type.
 utxosAt :: Address -> QueryM (Maybe Transaction.UtxoM)
 utxosAt addr = asks _.wallet >>= maybe (pure Nothing) (utxosAtByWallet addr)
+  where
+  -- Add more wallet types here:
+  utxosAtByWallet
+    :: Address -> Wallet -> QueryM (Maybe Transaction.UtxoM)
+  utxosAtByWallet address (Nami _) = namiUtxosAt address
+  -- Unreachable but helps build when we add wallets, most of them shouldn't
+  -- require any specific behaviour.
+  utxosAtByWallet address _ = allUtxosAt address
 
--- Add more wallet types here:
-utxosAtByWallet
-  :: Address -> Wallet -> QueryM (Maybe Transaction.UtxoM)
-utxosAtByWallet addr (Nami _) = utxosAtNami addr
--- Unreachable but helps build when we add wallets, most of them shouldn't
--- require any specific behaviour.
-utxosAtByWallet addr _ = utxosAt'' addr
+  -- Nami appear to remove collateral from the utxo set, so we shall do the same.
+  -- This is crucial if we are submitting via Nami. If we decide to submit with
+  -- Ogmios, we can remove this.
+  -- More detail can be found here https://github.com/Berry-Pool/nami-wallet/blob/ecb32e39173b28d4a7a85b279a748184d4759f6f/src/api/extension/index.js
+  -- by looking searching "// exclude collateral input from overall utxo set"
+  -- or functions getUtxos and checkCollateral.
+  namiUtxosAt :: Address -> QueryM (Maybe Transaction.UtxoM)
+  namiUtxosAt address = do
+    utxos' <- allUtxosAt address
+    collateral' <- getWalletCollateral
+    pure do
+      utxos <- unwrap <$> utxos'
+      collateral <- unwrap <$> collateral'
+      pure $ wrap $ Map.delete collateral.input utxos
 
 -- Gets utxos at an (internal) Address in terms of (internal) Transaction.Types.
-utxosAt'' :: Address -> QueryM (Maybe Transaction.UtxoM)
-utxosAt'' = addressToOgmiosAddress >>> getUtxos
+allUtxosAt :: Address -> QueryM (Maybe Transaction.UtxoM)
+allUtxosAt = addressToOgmiosAddress >>> getUtxos
   where
   getUtxos :: JsonWsp.Address -> QueryM (Maybe Transaction.UtxoM)
   getUtxos address = convertUtxos <$> utxosAt' address
@@ -426,18 +441,6 @@ utxosAt'' = addressToOgmiosAddress >>> getUtxos
       out = out' <#> bisequence # sequence
     in
       (wrap <<< Map.fromFoldable) <$> out
-
--- Nami appear to remove collateral from the utxo set, so we shall do the same.
--- This is crucial if we are submitting via Nami. If we decide to submit with
--- Ogmios, we can remove this.
-utxosAtNami :: Address -> QueryM (Maybe Transaction.UtxoM)
-utxosAtNami addr = do
-  utxos' <- utxosAt'' addr
-  collateral' <- getWalletCollateral
-  pure do
-    utxos <- unwrap <$> utxos'
-    collateral <- unwrap <$> collateral'
-    pure $ wrap $ Map.delete collateral.input utxos
 
 -- I think txId is a hexadecimal encoding.
 -- | Converts an Ogmios TxOutRef to (internal) TransactionInput

--- a/src/QueryM.purs
+++ b/src/QueryM.purs
@@ -432,7 +432,7 @@ utxosAt addr = asks _.wallet >>= maybe (pure Nothing) (utxosAtByWallet addr)
   -- This is crucial if we are submitting via Nami. If we decide to submit with
   -- Ogmios, we can remove this.
   -- More detail can be found here https://github.com/Berry-Pool/nami-wallet/blob/ecb32e39173b28d4a7a85b279a748184d4759f6f/src/api/extension/index.js
-  -- by looking searching "// exclude collateral input from overall utxo set"
+  -- by searching "// exclude collateral input from overall utxo set"
   -- or functions getUtxos and checkCollateral.
   namiUtxosAt :: Address -> QueryM (Maybe Transaction.UtxoM)
   namiUtxosAt address = do

--- a/src/QueryM.purs
+++ b/src/QueryM.purs
@@ -410,6 +410,8 @@ utxosAtNami addr = do
   utxos' <- getUtxos $ addressToOgmiosAddress addr
   collateral' <- getWalletCollateral
   -- Nami appear to remove collateral from the utxo set, so we shall do the same.
+  -- This is crucial if we are submitting via Nami. If we decide to submit with
+  -- Ogmios, we can remove this.
   pure do
     utxos <- unwrap <$> utxos'
     collateral <- unwrap <$> collateral'

--- a/src/QueryM.purs
+++ b/src/QueryM.purs
@@ -406,6 +406,7 @@ utxosAtByWallet addr (Nami _) = utxosAtNami addr
 -- require any specific behaviour.
 utxosAtByWallet addr _ = utxosAt'' addr
 
+-- Gets utxos at an (internal) Address in terms of (internal) Transaction.Types.
 utxosAt'' :: Address -> QueryM (Maybe Transaction.UtxoM)
 utxosAt'' = addressToOgmiosAddress >>> getUtxos
   where


### PR DESCRIPTION
- The pkh2pkh example is still showing ~ +4.83 Ada for the user when trying to submit with their UI collateral option.
- To submit a tx via Nami, it appears to be a requirement that the collateral is not used in the transaction input. Although theoretically, this is allowed: if a tx fails to validate, the collateral is the taken and the inputs (which may include collateral) aren't spent, if the tx validates then the collateral is left alone and the input (which again may include the collateral) is spent. In both scenarios, the collateral is used exactly once. For Nami specifically, if collateral is part of the input, then +5 Ada is automatically added to the transaction for the user despite the transaction balancing internally.
- Therefore, we want `utxosAt` for a Nami wallet to specifically filter out the collateral (since we're using Ogmios to get the utxo set).
- Added some logging for transactions.
- Should we decide to submit a tx via Ogmios, we can add the collateral back in, although the modularity of `utxosAt` may be useful if we need specific behaviour on this function for different wallets, although this should be unlikely and hopefully not required.
- Clean up balanceTxM with `ExceptT`