### PR TITLE
Configuration options for WS URLs

### DIFF
--- a/examples/nami/Pkh2Pkh.purs
+++ b/examples/nami/Pkh2Pkh.purs
@@ -52,6 +52,7 @@ import Effect.Aff.Class (liftAff)
 import Effect.Console as Console
 import QueryM
   ( QueryM
+  , defaultOgmiosWsConfig
   , defaultServerConfig
   , getWalletAddress
   , mkOgmiosWebSocketAff
@@ -79,7 +80,7 @@ import Wallet (mkNamiWalletAff)
 main :: Effect Unit
 main = launchAff_ $ do
   wallet <- Just <$> mkNamiWalletAff
-  ws <- mkOgmiosWebSocketAff "ws:127.0.0.1:1337"
+  ws <- mkOgmiosWebSocketAff defaultOgmiosWsConfig
   tx <- runReaderT
     buildTransaction
     { ws

--- a/src/QueryM.purs
+++ b/src/QueryM.purs
@@ -252,13 +252,13 @@ data OgmiosWebSocket = OgmiosWebSocket WebSocket Listeners
 -- smart-constructor for OgmiosWebSocket in Aff Context
 -- (prevents sending messages before the websocket opens, etc)
 mkOgmiosWebSocket'
-  :: Url
+  :: ServerConfig
   -> (Either Error OgmiosWebSocket -> Effect Unit)
   -> Effect Canceler
-mkOgmiosWebSocket' url cb = do
+mkOgmiosWebSocket' serverCfg cb = do
   utxoQueryDispatchIdMap <- createMutableDispatch
   let md = (messageDispatch utxoQueryDispatchIdMap)
-  ws <- _mkWebSocket url
+  ws <- _mkWebSocket $ mkWsUrl serverCfg
   _onWsConnect ws $ do
     _wsWatch ws (removeAllListeners utxoQueryDispatchIdMap)
     _onWsMessage ws (defaultMessageListener md)
@@ -271,8 +271,8 @@ mkOgmiosWebSocket' url cb = do
 -- . ((Either Error a -> Effect Unit) -> Effect Canceler)
 -- -> Aff a
 
-mkOgmiosWebSocketAff :: Url -> Aff OgmiosWebSocket
-mkOgmiosWebSocketAff url = makeAff (mkOgmiosWebSocket' url)
+mkOgmiosWebSocketAff :: ServerConfig -> Aff OgmiosWebSocket
+mkOgmiosWebSocketAff serverCfg = makeAff $ mkOgmiosWebSocket' serverCfg
 
 -- getter
 underlyingWebSocket :: OgmiosWebSocket -> WebSocket

--- a/test/AffInterface.purs
+++ b/test/AffInterface.purs
@@ -8,7 +8,14 @@ import Effect.Aff (Aff)
 import Effect.Class (liftEffect)
 import Effect.Exception (throw)
 import Mote (group, test)
-import QueryM (addressToOgmiosAddress, defaultServerConfig, mkOgmiosWebSocketAff, ogmiosAddressToAddress, utxosAt)
+import QueryM
+  ( addressToOgmiosAddress
+  , defaultServerConfig
+  , defaultOgmiosWsConfig
+  , mkOgmiosWebSocketAff
+  , ogmiosAddressToAddress
+  , utxosAt
+  )
 import Test.Spec.Assertions (shouldEqual)
 import TestM (TestPlanM)
 import Types.JsonWsp (Address)
@@ -39,7 +46,7 @@ suite = do
 
 testUtxosAt :: Address -> Aff Unit
 testUtxosAt testAddr = do
-  ws <- mkOgmiosWebSocketAff "ws:127.0.0.1:1337"
+  ws <- mkOgmiosWebSocketAff defaultOgmiosWsConfig
   case ogmiosAddressToAddress testAddr of
     Nothing -> liftEffect $ throw "Failed UtxosAt"
     Just addr -> runReaderT


### PR DESCRIPTION
Closes #95. Will make it more convenient as we add more websocket connections to `QueryConfig` (e.g. `ogmios-datum-cache`)