### PR TITLE
Add `ogmios-datum-cache` to shell environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,5 +29,16 @@ run-testnet-ogmios:
 run-haskell-server:
 	nix run -L .#cardano-browser-tx-server:exe:cardano-browser-tx-server
 
+run-datum-cache-postgres:
+	docker run -d --rm \
+		-e "POSTGRES_USER=ctxlib" \
+		-e "POSTGRES_PASSWORD=ctxlib" \
+		-e "POSTGRES_DB=ctxlib" \
+		-p 127.0.0.1:5432:5432 \
+		postgres:13
+
+run-datum-cache-postgres-console:
+	nix shell nixpkgs#postgresql -c psql postgresql://ctxlib:ctxlib@localhost:5432
+
 query-testnet-sync:
 	cardano-cli query tip --testnet-magic 1097911063

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ After starting the node, you can use `make query-testnet-sync` to check its sync
 
 In particular, `syncProgress` is the important part here.
 
+In order to query for datums, another service, `omgios-datum-cache`, is required. This service in turn depends on a running Postgresql instance. `ogmios-datum-cache` is available in the Nix shell environment. There is also a Makefile target to run a Postgres Docker container (`run-datum-cache-postgres`) with a username, password, and DB name corresponding to the `ogmios-datum-cache` configuration file (`config.toml`) in the repository root.
+
 ### Building the project & testing
 
 You can run `nix build` to build the Purescript project. `nix build .#check.<SYSTEM>` will build the packages (in the future, once we have a public `ogmios` instance to test against, this will run the tests as well; `nix flake check` unfortunately won't work because we depend on haskell.nix projects). `npm run test` can be used to only run the test suite.

--- a/config.toml
+++ b/config.toml
@@ -1,0 +1,13 @@
+# configuration file for `ogmios-datum-cache`
+
+dbConnectionString = "host=localhost port=5432 user=ctxlib dbname=ctxlib password=ctxlib"
+
+saveAllDatums = true
+
+server.port = 9999
+
+ogmios.address = "127.0.0.1"
+ogmios.port = 1337
+
+firstFetchBlock.slot = 44366242
+firstFetchBlock.id = "d2a4249fe3d0607535daa26caf12a38da2233586bc51e79ed0b3a36170471bf5"

--- a/flake.lock
+++ b/flake.lock
@@ -1146,6 +1146,22 @@
         "type": "github"
       }
     },
+    "ogmios-datum-cache": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1643991341,
+        "narHash": "sha256-MfHvoPcTrqX51Zv8ryzWZC6/t2TCtaFhTgJPY/vZ+iI=",
+        "owner": "mlabs-haskell",
+        "repo": "ogmios-datum-cache",
+        "rev": "64bf9307798fb104260c562455b9fb6736d78de0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "mlabs-haskell",
+        "repo": "ogmios-datum-cache",
+        "type": "github"
+      }
+    },
     "old-ghc-nix": {
       "flake": false,
       "locked": {
@@ -1305,7 +1321,12 @@
           "haskell-nix",
           "nixpkgs-2105"
         ],
+        "nixpkgs-unstable": [
+          "haskell-nix",
+          "nixpkgs-unstable"
+        ],
         "ogmios": "ogmios",
+        "ogmios-datum-cache": "ogmios-datum-cache",
         "optparse-applicative": "optparse-applicative",
         "ouroboros-network": "ouroboros-network",
         "plutus": "plutus",

--- a/flake.nix
+++ b/flake.nix
@@ -7,6 +7,10 @@
 
     # for the purescript project
     ogmios.url = "github:mlabs-haskell/ogmios";
+    ogmios-datum-cache = {
+      url = "github:mlabs-haskell/ogmios-datum-cache";
+      flake = false;
+    };
     # so named because we also need a different version of the repo below
     # in the server inputs and we use this one just for the `cardano-cli`
     # executables
@@ -26,6 +30,7 @@
     iohk-nix.url = "github:input-output-hk/iohk-nix";
     haskell-nix.url = "github:L-as/haskell.nix?ref=master";
     nixpkgs.follows = "haskell-nix/nixpkgs-2105";
+    nixpkgs-unstable.follows = "haskell-nix/nixpkgs-unstable";
     cardano-addresses = {
       url =
         "github:input-output-hk/cardano-addresses/d2f86caa085402a953920c6714a0de6a50b655ec";

--- a/nix/dev-shell.nix
+++ b/nix/dev-shell.nix
@@ -10,9 +10,16 @@
 
 with inputs;
 
+let
+  ogmios-dc = (
+    import inputs.nixpkgs-unstable { inherit system; }
+  ).haskellPackages.callPackage ogmios-datum-cache
+    { };
+in
 pkgs.mkShell {
   buildInputs = with easy-ps; [
     ogmios.packages.${system}."ogmios:exe:ogmios"
+    ogmios-dc
     cardano-node-exe.packages.${system}.cardano-cli
     compiler
     spago

--- a/nix/dev-shell.nix
+++ b/nix/dev-shell.nix
@@ -15,7 +15,7 @@ let
     # One of ODC's dependencies is marked as broken on the stable branch
     # We could just override that one package from unstable, but it's more
     # convenient to just use unstable to build the package
-    import inputs.nixpkgs-unstable { inherit system; }
+    import nixpkgs-unstable { inherit system; }
   ).haskellPackages.callPackage ogmios-datum-cache
     { };
 in

--- a/nix/dev-shell.nix
+++ b/nix/dev-shell.nix
@@ -12,6 +12,9 @@ with inputs;
 
 let
   ogmios-dc = (
+    # One of ODC's dependencies is marked as broken on the stable branch
+    # We could just override that one package from unstable, but it's more
+    # convenient to just use unstable to build the package
     import inputs.nixpkgs-unstable { inherit system; }
   ).haskellPackages.callPackage ogmios-datum-cache
     { };


### PR DESCRIPTION
Closes #39 

- The executable can be run from the shell using the same name as the project
- `config.toml` is the configuration file for the service
- Since `ogmios-datum-cache` depends on a running Postgres instance, I added a Makefile target to run it via Docker