### PR TITLE
Upgrade Ogmios fork to v5.2.0

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -65,6 +65,23 @@
         "type": "github"
       }
     },
+    "Win32-network_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1627315969,
+        "narHash": "sha256-Hesb5GXSx0IwKSIi42ofisVELcQNX6lwHcoZcbaDiqc=",
+        "owner": "input-output-hk",
+        "repo": "Win32-network",
+        "rev": "3825d3abf75f83f406c1f7161883c438dac7277d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "Win32-network",
+        "rev": "3825d3abf75f83f406c1f7161883c438dac7277d",
+        "type": "github"
+      }
+    },
     "cabal-32": {
       "flake": false,
       "locked": {
@@ -86,10 +103,10 @@
       "flake": false,
       "locked": {
         "lastModified": 1603716527,
-        "narHash": "sha256-sDbrmur9Zfp4mPKohCD8IDZfXJ0Tjxpmr2R+kg5PpSY=",
+        "narHash": "sha256-X0TFfdD4KZpwl0Zr6x+PLxUt/VyKQfX7ylXHdmZIL+w=",
         "owner": "haskell",
         "repo": "cabal",
-        "rev": "94aaa8e4720081f9c75497e2735b90f6a819b08e",
+        "rev": "48bf10787e27364730dd37a42b603cee8d6af7ee",
         "type": "github"
       },
       "original": {
@@ -136,11 +153,11 @@
     "cabal-34_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1622475795,
-        "narHash": "sha256-chwTL304Cav+7p38d9mcb+egABWmxo2Aq+xgVBgEb/U=",
+        "lastModified": 1640353650,
+        "narHash": "sha256-N1t6M3/wqj90AEdRkeC8i923gQYUpzSr8b40qVOZ1Rk=",
         "owner": "haskell",
         "repo": "cabal",
-        "rev": "b086c1995cdd616fc8d91f46a21e905cc50a1049",
+        "rev": "942639c18c0cd8ec53e0a6f8d120091af35312cd",
         "type": "github"
       },
       "original": {
@@ -170,11 +187,28 @@
     "cabal-36": {
       "flake": false,
       "locked": {
-        "lastModified": 1640163203,
-        "narHash": "sha256-TwDWP2CffT0j40W6zr0J1Qbu+oh3nsF1lUx9446qxZM=",
+        "lastModified": 1641652457,
+        "narHash": "sha256-BlFPKP4C4HRUJeAbdembX1Rms1LD380q9s0qVDeoAak=",
         "owner": "haskell",
         "repo": "cabal",
-        "rev": "ecf418050c1821f25e2e218f1be94c31e0465df1",
+        "rev": "f27667f8ec360c475027dcaee0138c937477b070",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.6",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
+    "cabal-36_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1646338512,
+        "narHash": "sha256-A4ZkpUZC7JDdvMYB+sxaG3mFmsYzXKIW2jybT1KoFFU=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "60466878c23057f08063a49ef807d8b8313bb6cc",
         "type": "github"
       },
       "original": {
@@ -218,6 +252,23 @@
         "type": "github"
       }
     },
+    "cardano-base_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1635841753,
+        "narHash": "sha256-OXKsJ1UTj5kJ9xaThM54ZmxFAiFINTPKd4JQa4dPmEU=",
+        "owner": "input-output-hk",
+        "repo": "cardano-base",
+        "rev": "41545ba3ac6b3095966316a99883d678b5ab8da8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "cardano-base",
+        "rev": "41545ba3ac6b3095966316a99883d678b5ab8da8",
+        "type": "github"
+      }
+    },
     "cardano-configurations": {
       "flake": false,
       "locked": {
@@ -248,6 +299,40 @@
         "owner": "input-output-hk",
         "repo": "cardano-crypto",
         "rev": "07397f0e50da97eaa0575d93bee7ac4b2b2576ec",
+        "type": "github"
+      }
+    },
+    "cardano-crypto_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1604244485,
+        "narHash": "sha256-2Fipex/WjIRMrvx6F3hjJoAeMtFd2wGnZECT0kuIB9k=",
+        "owner": "input-output-hk",
+        "repo": "cardano-crypto",
+        "rev": "f73079303f663e028288f9f4a9e08bcca39a923e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "cardano-crypto",
+        "rev": "f73079303f663e028288f9f4a9e08bcca39a923e",
+        "type": "github"
+      }
+    },
+    "cardano-ledger": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1639498285,
+        "narHash": "sha256-lRNfkGMHnpPO0T19FZY5BnuRkr0zTRZIkxZVgHH0fys=",
+        "owner": "input-output-hk",
+        "repo": "cardano-ledger",
+        "rev": "1a9ec4ae9e0b09d54e49b2a40c4ead37edadcce5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "cardano-ledger",
+        "rev": "1a9ec4ae9e0b09d54e49b2a40c4ead37edadcce5",
         "type": "github"
       }
     },
@@ -312,6 +397,23 @@
         "type": "github"
       }
     },
+    "cardano-node_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1640022647,
+        "narHash": "sha256-M+YnF7Zj/7QK2pu0T75xNVaX0eEeijtBH8yz+jEHIMM=",
+        "owner": "input-output-hk",
+        "repo": "cardano-node",
+        "rev": "814df2c146f5d56f8c35a681fe75e85b905aed5d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "cardano-node",
+        "rev": "814df2c146f5d56f8c35a681fe75e85b905aed5d",
+        "type": "github"
+      }
+    },
     "cardano-prelude": {
       "flake": false,
       "locked": {
@@ -326,6 +428,23 @@
         "owner": "input-output-hk",
         "repo": "cardano-prelude",
         "rev": "fd773f7a58412131512b9f694ab95653ac430852",
+        "type": "github"
+      }
+    },
+    "cardano-prelude_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1617089317,
+        "narHash": "sha256-kgX3DKyfjBb8/XcDEd+/adlETsFlp5sCSurHWgsFAQI=",
+        "owner": "input-output-hk",
+        "repo": "cardano-prelude",
+        "rev": "bb4ed71ba8e587f672d06edf9d2e376f4b055555",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "cardano-prelude",
+        "rev": "bb4ed71ba8e587f672d06edf9d2e376f4b055555",
         "type": "github"
       }
     },
@@ -444,17 +563,16 @@
     "flake-compat_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1627913399,
-        "narHash": "sha256-hY8g6H2KFL8ownSiFeMOjwPC8P0ueXpCVEbxgda3pko=",
+        "lastModified": 1641205782,
+        "narHash": "sha256-4jY7RCWUoZ9cKD8co0/4tFARpWB+57+r1bLLvXNJliY=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "12c64ca55c1014cdc1b16ed5a804aa8576601ff2",
+        "rev": "b7547d3eed6f32d06102ead8991ec52ab0a4f1a7",
         "type": "github"
       },
       "original": {
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "12c64ca55c1014cdc1b16ed5a804aa8576601ff2",
         "type": "github"
       }
     },
@@ -475,11 +593,11 @@
     },
     "flake-utils_2": {
       "locked": {
-        "lastModified": 1623875721,
-        "narHash": "sha256-A8BU7bjS5GirpAUv4QA+QnJ4CceLHkcXdRp4xITDB0s=",
+        "lastModified": 1644229661,
+        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "f7e004a55b120c02ecb6219596820fcd32ca8772",
+        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
         "type": "github"
       },
       "original": {
@@ -489,21 +607,6 @@
       }
     },
     "flake-utils_3": {
-      "locked": {
-        "lastModified": 1638122382,
-        "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "74f7e4319258e287b0f9cb95426c9853b282730b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_4": {
       "locked": {
         "lastModified": 1623875721,
         "narHash": "sha256-A8BU7bjS5GirpAUv4QA+QnJ4CceLHkcXdRp4xITDB0s=",
@@ -519,6 +622,23 @@
       }
     },
     "flat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1628771504,
+        "narHash": "sha256-lRFND+ZnZvAph6ZYkr9wl9VAx41pb3uSFP8Wc7idP9M=",
+        "owner": "input-output-hk",
+        "repo": "flat",
+        "rev": "ee59880f47ab835dbd73bea0847dab7869fc20d8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "flat",
+        "rev": "ee59880f47ab835dbd73bea0847dab7869fc20d8",
+        "type": "github"
+      }
+    },
+    "flat_2": {
       "flake": false,
       "locked": {
         "lastModified": 1628771504,
@@ -603,6 +723,23 @@
         "type": "github"
       }
     },
+    "goblins_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1598362523,
+        "narHash": "sha256-z9ut0y6umDIjJIRjz9KSvKgotuw06/S8QDwOtVdGiJ0=",
+        "owner": "input-output-hk",
+        "repo": "goblins",
+        "rev": "cde90a2b27f79187ca8310b6549331e59595e7ba",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "goblins",
+        "rev": "cde90a2b27f79187ca8310b6549331e59595e7ba",
+        "type": "github"
+      }
+    },
     "hackage": {
       "flake": false,
       "locked": {
@@ -622,11 +759,11 @@
     "hackage_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1642122772,
-        "narHash": "sha256-bMK+/5l+NDlFoyCSqa5B9mcEuEBum/SA428Luy6VkCs=",
+        "lastModified": 1644887696,
+        "narHash": "sha256-o4gltv4npUl7+1gEQIcrRqZniwqC9kK8QsPaftlrawc=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "fd69993f41543b27f373d4ad1cef1f2a2a333945",
+        "rev": "6ff64aa49b88e75dd6e0bbd2823c2a92c9174fa5",
         "type": "github"
       },
       "original": {
@@ -665,7 +802,7 @@
         "nix-tools": "nix-tools_2",
         "nixpkgs": [
           "haskell-nix",
-          "nixpkgs-2111"
+          "nixpkgs-unstable"
         ],
         "nixpkgs-2003": "nixpkgs-2003_2",
         "nixpkgs-2105": "nixpkgs-2105_2",
@@ -675,11 +812,11 @@
         "stackage": "stackage_2"
       },
       "locked": {
-        "lastModified": 1642415322,
-        "narHash": "sha256-zZEeWWnTA9w7af8xeSX6OtdsmiM7I6Ez0J6CAMwTck4=",
+        "lastModified": 1644944726,
+        "narHash": "sha256-jJWdP/3Ne1y1akC3m9rSO5ItRoBc4UTdVQZBCuPmmrM=",
         "owner": "L-as",
         "repo": "haskell.nix",
-        "rev": "841487f6bc87b2e9461bd448075e88fc59465df1",
+        "rev": "45c583b5580c130487eb5a342679f0bdbc2b23fc",
         "type": "github"
       },
       "original": {
@@ -694,36 +831,35 @@
         "HTTP": "HTTP_3",
         "cabal-32": "cabal-32_3",
         "cabal-34": "cabal-34_3",
+        "cabal-36": "cabal-36_2",
         "cardano-shell": "cardano-shell_3",
-        "flake-utils": "flake-utils_4",
+        "flake-utils": "flake-utils_3",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_3",
         "hackage": "hackage_3",
         "hpc-coveralls": "hpc-coveralls_3",
         "nix-tools": "nix-tools_3",
         "nixpkgs": [
-          "ogmios",
-          "haskell-nix",
-          "nixpkgs-2105"
+          "nixpkgs-unstable"
         ],
         "nixpkgs-2003": "nixpkgs-2003_3",
-        "nixpkgs-2009": "nixpkgs-2009_2",
         "nixpkgs-2105": "nixpkgs-2105_3",
+        "nixpkgs-2111": "nixpkgs-2111_2",
         "nixpkgs-unstable": "nixpkgs-unstable_3",
         "old-ghc-nix": "old-ghc-nix_3",
         "stackage": "stackage_3"
       },
       "locked": {
-        "lastModified": 1637101192,
-        "narHash": "sha256-FMAwhSBCE4+iRBim+4H81ZSf6WsAnn5NLlpedWBOYJM=",
-        "owner": "input-output-hk",
+        "lastModified": 1644944726,
+        "narHash": "sha256-jJWdP/3Ne1y1akC3m9rSO5ItRoBc4UTdVQZBCuPmmrM=",
+        "owner": "L-as",
         "repo": "haskell.nix",
-        "rev": "64cd5f70ce0d619390039a1a3d57c442552b0924",
+        "rev": "45c583b5580c130487eb5a342679f0bdbc2b23fc",
         "type": "github"
       },
       "original": {
-        "owner": "input-output-hk",
+        "owner": "L-as",
+        "ref": "master",
         "repo": "haskell.nix",
-        "rev": "64cd5f70ce0d619390039a1a3d57c442552b0924",
         "type": "github"
       }
     },
@@ -760,6 +896,57 @@
       "original": {
         "owner": "input-output-hk",
         "repo": "haskell.nix",
+        "type": "github"
+      }
+    },
+    "hedgehog-extras": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1626138074,
+        "narHash": "sha256-KYLGLpDGHWlb/Gcx6Q/2HTnRMzZQmPKz0JbIw+bHh3E=",
+        "owner": "input-output-hk",
+        "repo": "hedgehog-extras",
+        "rev": "edf6945007177a638fbeb8802397f3a6f4e47c14",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "hedgehog-extras",
+        "rev": "edf6945007177a638fbeb8802397f3a6f4e47c14",
+        "type": "github"
+      }
+    },
+    "hjsonpointer": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1538408336,
+        "narHash": "sha256-l2GZpN5SGalPalIa8xcHOdafSQqLK1Y66aYWOVElwlk=",
+        "owner": "KtorZ",
+        "repo": "hjsonpointer",
+        "rev": "75ed0d049c33274a6cb4c36c8538d4bf2ef9c30e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "KtorZ",
+        "repo": "hjsonpointer",
+        "rev": "75ed0d049c33274a6cb4c36c8538d4bf2ef9c30e",
+        "type": "github"
+      }
+    },
+    "hjsonschema": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1588363390,
+        "narHash": "sha256-lep5HGrtxp/XN72WXY1JVk5lJ5cE0XMhxKwjMpCoAxk=",
+        "owner": "KtorZ",
+        "repo": "hjsonschema",
+        "rev": "fde6e676f79f3f3320a558f20492ad816a2543a7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "KtorZ",
+        "repo": "hjsonschema",
+        "rev": "fde6e676f79f3f3320a558f20492ad816a2543a7",
         "type": "github"
       }
     },
@@ -812,6 +999,23 @@
       }
     },
     "iohk-monitoring-framework": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1624367860,
+        "narHash": "sha256-QE3QRpIHIABm+qCP/wP4epbUx0JmSJ9BMePqWEd3iMY=",
+        "owner": "input-output-hk",
+        "repo": "iohk-monitoring-framework",
+        "rev": "46f994e216a1f8b36fe4669b47b2a7011b0e153c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "iohk-monitoring-framework",
+        "rev": "46f994e216a1f8b36fe4669b47b2a7011b0e153c",
+        "type": "github"
+      }
+    },
+    "iohk-monitoring-framework_2": {
       "flake": false,
       "locked": {
         "lastModified": 1624367860,
@@ -886,11 +1090,11 @@
     "nix-tools_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1636018067,
-        "narHash": "sha256-ng306fkuwr6V/malWtt3979iAC4yMVDDH2ViwYB6sQE=",
+        "lastModified": 1644395812,
+        "narHash": "sha256-BVFk/BEsTLq5MMZvdy3ZYHKfaS3dHrsKh4+tb5t5b58=",
         "owner": "input-output-hk",
         "repo": "nix-tools",
-        "rev": "ed5bd7215292deba55d6ab7a4e8c21f8b1564dda",
+        "rev": "d847c63b99bbec78bf83be2a61dc9f09b8a9ccc1",
         "type": "github"
       },
       "original": {
@@ -992,22 +1196,6 @@
         "type": "github"
       }
     },
-    "nixpkgs-2009_2": {
-      "locked": {
-        "lastModified": 1624271064,
-        "narHash": "sha256-qns/uRW7MR2EfVf6VEeLgCsCp7pIOjDeR44JzTF09MA=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "46d1c3f28ca991601a53e9a14fdd53fcd3dd8416",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-20.09-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixpkgs-2105": {
       "locked": {
         "lastModified": 1630481079,
@@ -1026,11 +1214,11 @@
     },
     "nixpkgs-2105_2": {
       "locked": {
-        "lastModified": 1640283157,
-        "narHash": "sha256-6Ddfop+rKE+Gl9Tjp9YIrkfoYPzb8F80ergdjcq3/MY=",
+        "lastModified": 1642244250,
+        "narHash": "sha256-vWpUEqQdVP4srj+/YLJRTN9vjpTs4je0cdWKXPbDItc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "dde1557825c5644c869c5efc7448dc03722a8f09",
+        "rev": "0fd9ee1aa36ce865ad273f4f07fdc093adeb5c00",
         "type": "github"
       },
       "original": {
@@ -1058,11 +1246,27 @@
     },
     "nixpkgs-2111": {
       "locked": {
-        "lastModified": 1640283207,
-        "narHash": "sha256-SCwl7ZnCfMDsuSYvwIroiAlk7n33bW8HFfY8NvKhcPA=",
+        "lastModified": 1644510859,
+        "narHash": "sha256-xjpVvL5ecbyi0vxtVl/Fh9bwGlMbw3S06zE5nUzFB8A=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "64c7e3388bbd9206e437713351e814366e0c3284",
+        "rev": "0d1d5d7e3679fec9d07f2eb804d9f9fdb98378d3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-21.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2111_2": {
+      "locked": {
+        "lastModified": 1646416052,
+        "narHash": "sha256-bfV62gYQGYjb/Gvw6MdMuEvWCcC838mI1Dzi1efjqTA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c78fc23f108b9a3bea9bf8693d2943ee0269c804",
         "type": "github"
       },
       "original": {
@@ -1090,11 +1294,11 @@
     },
     "nixpkgs-unstable_2": {
       "locked": {
-        "lastModified": 1641285291,
-        "narHash": "sha256-KYaOBNGar3XWTxTsYPr9P6u74KAqNq0wobEC236U+0c=",
+        "lastModified": 1644486793,
+        "narHash": "sha256-EeijR4guVHgVv+JpOX3cQO+1XdrkJfGmiJ9XVsVU530=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0432195a4b8d68faaa7d3d4b355260a3120aeeae",
+        "rev": "1882c6b7368fd284ad01b0a5b5601ef136321292",
         "type": "github"
       },
       "original": {
@@ -1120,29 +1324,58 @@
         "type": "github"
       }
     },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1640283157,
+        "narHash": "sha256-6Ddfop+rKE+Gl9Tjp9YIrkfoYPzb8F80ergdjcq3/MY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "dde1557825c5644c869c5efc7448dc03722a8f09",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "dde1557825c5644c869c5efc7448dc03722a8f09",
+        "type": "github"
+      }
+    },
     "ogmios": {
       "inputs": {
+        "Win32-network": "Win32-network_2",
+        "cardano-base": "cardano-base_2",
+        "cardano-crypto": "cardano-crypto_2",
+        "cardano-ledger": "cardano-ledger",
+        "cardano-node": "cardano-node_2",
+        "cardano-prelude": "cardano-prelude_2",
         "flake-compat": "flake-compat_2",
-        "flake-utils": "flake-utils_3",
+        "flat": "flat_2",
+        "goblins": "goblins_2",
         "haskell-nix": "haskell-nix_2",
+        "hedgehog-extras": "hedgehog-extras",
+        "hjsonpointer": "hjsonpointer",
+        "hjsonschema": "hjsonschema",
+        "iohk-monitoring-framework": "iohk-monitoring-framework_2",
         "nixpkgs": [
-          "ogmios",
           "haskell-nix",
-          "nixpkgs-unstable"
+          "nixpkgs-2105"
         ],
-        "plutusSrc": "plutusSrc"
+        "ouroboros-network": "ouroboros-network",
+        "plutus": "plutus",
+        "wai-routes": "wai-routes"
       },
       "locked": {
-        "lastModified": 1641299862,
-        "narHash": "sha256-orby56zTKJCp+fCRp2nnLeJzABHgLHJ8LFwzrH3wMFc=",
+        "lastModified": 1646827481,
+        "narHash": "sha256-g1nT4xKLw6WF5hOTF21xd2fSakYiaXRrwy4LVy8XYKY=",
         "owner": "mlabs-haskell",
         "repo": "ogmios",
-        "rev": "654408ed2d6f7f4a5a80297a37808f1174264190",
+        "rev": "e78fd982e720c93a24607d37c6f6f5188da27929",
         "type": "github"
       },
       "original": {
         "owner": "mlabs-haskell",
         "repo": "ogmios",
+        "rev": "e78fd982e720c93a24607d37c6f6f5188da27929",
         "type": "github"
       }
     },
@@ -1233,6 +1466,23 @@
     "ouroboros-network": {
       "flake": false,
       "locked": {
+        "lastModified": 1639767242,
+        "narHash": "sha256-n/4it/p3OxqtzVHESgZIZVdgFBsSNlvjYdTvxC0gc3I=",
+        "owner": "input-output-hk",
+        "repo": "ouroboros-network",
+        "rev": "32af91686b86dac7454eee8b8a8d6e97a80638da",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "ouroboros-network",
+        "rev": "32af91686b86dac7454eee8b8a8d6e97a80638da",
+        "type": "github"
+      }
+    },
+    "ouroboros-network_2": {
+      "flake": false,
+      "locked": {
         "lastModified": 1634917006,
         "narHash": "sha256-lwTgyoZBQAaU6Sh7BouGJGUvK1tSVrWhJP63v7MpwKA=",
         "owner": "input-output-hk",
@@ -1250,23 +1500,6 @@
     "plutus": {
       "flake": false,
       "locked": {
-        "lastModified": 1634957126,
-        "narHash": "sha256-BhGQPiCv4UxVs0XEdMMddaNWiztmkoeJotpW/lrtqNs=",
-        "owner": "input-output-hk",
-        "repo": "plutus",
-        "rev": "3f089ccf0ca746b399c99afe51e063b0640af547",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "repo": "plutus",
-        "rev": "3f089ccf0ca746b399c99afe51e063b0640af547",
-        "type": "github"
-      }
-    },
-    "plutusSrc": {
-      "flake": false,
-      "locked": {
         "lastModified": 1632818067,
         "narHash": "sha256-jiqrzS519eoHg9NqTr4UZOVme3uIACL17OCiDMn0LMo=",
         "owner": "input-output-hk",
@@ -1278,6 +1511,23 @@
         "owner": "input-output-hk",
         "repo": "plutus",
         "rev": "1efbb276ef1a10ca6961d0fd32e6141e9798bd11",
+        "type": "github"
+      }
+    },
+    "plutus_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1634957126,
+        "narHash": "sha256-BhGQPiCv4UxVs0XEdMMddaNWiztmkoeJotpW/lrtqNs=",
+        "owner": "input-output-hk",
+        "repo": "plutus",
+        "rev": "3f089ccf0ca746b399c99afe51e063b0640af547",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "plutus",
+        "rev": "3f089ccf0ca746b399c99afe51e063b0640af547",
         "type": "github"
       }
     },
@@ -1317,10 +1567,7 @@
         "haskell-nix": "haskell-nix",
         "iohk-monitoring-framework": "iohk-monitoring-framework",
         "iohk-nix": "iohk-nix",
-        "nixpkgs": [
-          "haskell-nix",
-          "nixpkgs-2105"
-        ],
+        "nixpkgs": "nixpkgs_2",
         "nixpkgs-unstable": [
           "haskell-nix",
           "nixpkgs-unstable"
@@ -1328,8 +1575,8 @@
         "ogmios": "ogmios",
         "ogmios-datum-cache": "ogmios-datum-cache",
         "optparse-applicative": "optparse-applicative",
-        "ouroboros-network": "ouroboros-network",
-        "plutus": "plutus",
+        "ouroboros-network": "ouroboros-network_2",
+        "plutus": "plutus_2",
         "purescript-bridge": "purescript-bridge",
         "servant-purescript": "servant-purescript"
       }
@@ -1370,11 +1617,11 @@
     "stackage_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1642123041,
-        "narHash": "sha256-4F4qUsuisoeAZ2vGFoVNQiNHr6G69kmgHGwIG0OEuHw=",
+        "lastModified": 1644887829,
+        "narHash": "sha256-tjUXJpqB7MMnqM4FF5cdtZipfratUcTKRQVA6F77sEQ=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "21504c386a158e5bcb5c5cf5ae6f34545880ce23",
+        "rev": "db8bdef6588cf4f38e6069075ba76f0024381f68",
         "type": "github"
       },
       "original": {
@@ -1411,6 +1658,23 @@
       "original": {
         "owner": "numtide",
         "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "wai-routes": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1608703392,
+        "narHash": "sha256-MW4lZUBjTwqBT97q7YOCHKBZTVWo2yAuvPVqgRmc74Q=",
+        "owner": "KtorZ",
+        "repo": "wai-routes",
+        "rev": "d74b39683792649c01113f40bf57724dcf95c96a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "KtorZ",
+        "repo": "wai-routes",
+        "rev": "d74b39683792649c01113f40bf57724dcf95c96a",
         "type": "github"
       }
     }

--- a/flake.lock
+++ b/flake.lock
@@ -120,10 +120,10 @@
       "flake": false,
       "locked": {
         "lastModified": 1603716527,
-        "narHash": "sha256-sDbrmur9Zfp4mPKohCD8IDZfXJ0Tjxpmr2R+kg5PpSY=",
+        "narHash": "sha256-X0TFfdD4KZpwl0Zr6x+PLxUt/VyKQfX7ylXHdmZIL+w=",
         "owner": "haskell",
         "repo": "cabal",
-        "rev": "94aaa8e4720081f9c75497e2735b90f6a819b08e",
+        "rev": "48bf10787e27364730dd37a42b603cee8d6af7ee",
         "type": "github"
       },
       "original": {
@@ -170,11 +170,11 @@
     "cabal-34_3": {
       "flake": false,
       "locked": {
-        "lastModified": 1622475795,
-        "narHash": "sha256-chwTL304Cav+7p38d9mcb+egABWmxo2Aq+xgVBgEb/U=",
+        "lastModified": 1640353650,
+        "narHash": "sha256-N1t6M3/wqj90AEdRkeC8i923gQYUpzSr8b40qVOZ1Rk=",
         "owner": "haskell",
         "repo": "cabal",
-        "rev": "b086c1995cdd616fc8d91f46a21e905cc50a1049",
+        "rev": "942639c18c0cd8ec53e0a6f8d120091af35312cd",
         "type": "github"
       },
       "original": {
@@ -204,11 +204,11 @@
     "cabal-36_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1646338512,
-        "narHash": "sha256-A4ZkpUZC7JDdvMYB+sxaG3mFmsYzXKIW2jybT1KoFFU=",
+        "lastModified": 1641652457,
+        "narHash": "sha256-BlFPKP4C4HRUJeAbdembX1Rms1LD380q9s0qVDeoAak=",
         "owner": "haskell",
         "repo": "cabal",
-        "rev": "60466878c23057f08063a49ef807d8b8313bb6cc",
+        "rev": "f27667f8ec360c475027dcaee0138c937477b070",
         "type": "github"
       },
       "original": {
@@ -531,11 +531,11 @@
     "easy-purescript-nix": {
       "flake": false,
       "locked": {
-        "lastModified": 1641236510,
-        "narHash": "sha256-JEabdJ+3cZEYDVnzgMH/YFsaGtIBiCFcgvVO9XRgiY4=",
+        "lastModified": 1646209831,
+        "narHash": "sha256-or8Z6aMWdrqcmFA0hhjjb6FIiW14C0ruwXAqy+zYZ8g=",
         "owner": "justinwoo",
         "repo": "easy-purescript-nix",
-        "rev": "678070816270726e2f428da873fe3f2736201f42",
+        "rev": "aa72388ca0fb72ed64467f59a121db1f104897db",
         "type": "github"
       },
       "original": {
@@ -608,11 +608,11 @@
     },
     "flake-utils_3": {
       "locked": {
-        "lastModified": 1623875721,
-        "narHash": "sha256-A8BU7bjS5GirpAUv4QA+QnJ4CceLHkcXdRp4xITDB0s=",
+        "lastModified": 1644229661,
+        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "f7e004a55b120c02ecb6219596820fcd32ca8772",
+        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
         "type": "github"
       },
       "original": {
@@ -775,11 +775,11 @@
     "hackage_3": {
       "flake": false,
       "locked": {
-        "lastModified": 1637025275,
-        "narHash": "sha256-8u/guDMDQpxCaV8awtEDcS8KyH7KaCcSvVS9xp0lti0=",
+        "lastModified": 1644887696,
+        "narHash": "sha256-o4gltv4npUl7+1gEQIcrRqZniwqC9kK8QsPaftlrawc=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "8729519e277dc8f3768c8f360965bbf545c14d35",
+        "rev": "6ff64aa49b88e75dd6e0bbd2823c2a92c9174fa5",
         "type": "github"
       },
       "original": {
@@ -839,6 +839,8 @@
         "hpc-coveralls": "hpc-coveralls_3",
         "nix-tools": "nix-tools_3",
         "nixpkgs": [
+          "ogmios",
+          "haskell-nix",
           "nixpkgs-unstable"
         ],
         "nixpkgs-2003": "nixpkgs-2003_3",
@@ -1037,11 +1039,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1642517206,
-        "narHash": "sha256-mMEq8LxansMCt3qzRCa1qiovvZWLYt6yAMoFSl3lq7w=",
+        "lastModified": 1646330344,
+        "narHash": "sha256-EbhMDeneH26wDi+x5kz8nfru/dE9JZ241hJed4a8lz8=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "62d853d3216083ecadc8e7f192498bebad4eee76",
+        "rev": "0a0126d8fb1bdc61ce1fd2ef61cf396de800fdad",
         "type": "github"
       },
       "original": {
@@ -1106,11 +1108,11 @@
     "nix-tools_3": {
       "flake": false,
       "locked": {
-        "lastModified": 1636018067,
-        "narHash": "sha256-ng306fkuwr6V/malWtt3979iAC4yMVDDH2ViwYB6sQE=",
+        "lastModified": 1644395812,
+        "narHash": "sha256-BVFk/BEsTLq5MMZvdy3ZYHKfaS3dHrsKh4+tb5t5b58=",
         "owner": "input-output-hk",
         "repo": "nix-tools",
-        "rev": "ed5bd7215292deba55d6ab7a4e8c21f8b1564dda",
+        "rev": "d847c63b99bbec78bf83be2a61dc9f09b8a9ccc1",
         "type": "github"
       },
       "original": {
@@ -1230,11 +1232,11 @@
     },
     "nixpkgs-2105_3": {
       "locked": {
-        "lastModified": 1630481079,
-        "narHash": "sha256-leWXLchbAbqOlLT6tju631G40SzQWPqaAXQG3zH1Imw=",
+        "lastModified": 1642244250,
+        "narHash": "sha256-vWpUEqQdVP4srj+/YLJRTN9vjpTs4je0cdWKXPbDItc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "110a2c9ebbf5d4a94486854f18a37a938cfacbbb",
+        "rev": "0fd9ee1aa36ce865ad273f4f07fdc093adeb5c00",
         "type": "github"
       },
       "original": {
@@ -1262,11 +1264,11 @@
     },
     "nixpkgs-2111_2": {
       "locked": {
-        "lastModified": 1646416052,
-        "narHash": "sha256-bfV62gYQGYjb/Gvw6MdMuEvWCcC838mI1Dzi1efjqTA=",
+        "lastModified": 1644510859,
+        "narHash": "sha256-xjpVvL5ecbyi0vxtVl/Fh9bwGlMbw3S06zE5nUzFB8A=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c78fc23f108b9a3bea9bf8693d2943ee0269c804",
+        "rev": "0d1d5d7e3679fec9d07f2eb804d9f9fdb98378d3",
         "type": "github"
       },
       "original": {
@@ -1310,11 +1312,11 @@
     },
     "nixpkgs-unstable_3": {
       "locked": {
-        "lastModified": 1635295995,
-        "narHash": "sha256-sGYiXjFlxTTMNb4NSkgvX+knOOTipE6gqwPUQpxNF+c=",
+        "lastModified": 1644486793,
+        "narHash": "sha256-EeijR4guVHgVv+JpOX3cQO+1XdrkJfGmiJ9XVsVU530=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "22a500a3f87bbce73bd8d777ef920b43a636f018",
+        "rev": "1882c6b7368fd284ad01b0a5b5601ef136321292",
         "type": "github"
       },
       "original": {
@@ -1357,6 +1359,7 @@
         "hjsonschema": "hjsonschema",
         "iohk-monitoring-framework": "iohk-monitoring-framework_2",
         "nixpkgs": [
+          "ogmios",
           "haskell-nix",
           "nixpkgs-2105"
         ],
@@ -1365,28 +1368,28 @@
         "wai-routes": "wai-routes"
       },
       "locked": {
-        "lastModified": 1646827481,
-        "narHash": "sha256-g1nT4xKLw6WF5hOTF21xd2fSakYiaXRrwy4LVy8XYKY=",
+        "lastModified": 1646900647,
+        "narHash": "sha256-UIUu3B1ONjXCnNJjLwgeGxczo00FrSUd2Iwg1mSb8VQ=",
         "owner": "mlabs-haskell",
         "repo": "ogmios",
-        "rev": "e78fd982e720c93a24607d37c6f6f5188da27929",
+        "rev": "c4f896bf32ad066be8edd8681ee11e4ab059be7f",
         "type": "github"
       },
       "original": {
         "owner": "mlabs-haskell",
         "repo": "ogmios",
-        "rev": "e78fd982e720c93a24607d37c6f6f5188da27929",
+        "rev": "c4f896bf32ad066be8edd8681ee11e4ab059be7f",
         "type": "github"
       }
     },
     "ogmios-datum-cache": {
       "flake": false,
       "locked": {
-        "lastModified": 1643991341,
-        "narHash": "sha256-MfHvoPcTrqX51Zv8ryzWZC6/t2TCtaFhTgJPY/vZ+iI=",
+        "lastModified": 1645121099,
+        "narHash": "sha256-xbTjfOUJ3yBbiFpq4fIT4dVKCeNDtdsyd69b6KY688U=",
         "owner": "mlabs-haskell",
         "repo": "ogmios-datum-cache",
-        "rev": "64bf9307798fb104260c562455b9fb6736d78de0",
+        "rev": "2926187ea4ac5bfdaf8a73bb7de3c5c76f3b8ae1",
         "type": "github"
       },
       "original": {
@@ -1633,11 +1636,11 @@
     "stackage_3": {
       "flake": false,
       "locked": {
-        "lastModified": 1637026030,
-        "narHash": "sha256-kX+/OY8lW7LXHDCcgSXm1A7tqdozdB7Ehv34rTcxZbQ=",
+        "lastModified": 1644887829,
+        "narHash": "sha256-tjUXJpqB7MMnqM4FF5cdtZipfratUcTKRQVA6F77sEQ=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "1fd6171f1266cec4791573e91ec54fbcc93034eb",
+        "rev": "db8bdef6588cf4f38e6069075ba76f0024381f68",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,7 @@
     nixpkgs.url = "github:NixOS/nixpkgs/dde1557825c5644c869c5efc7448dc03722a8f09";
 
     # for the purescript project
-    ogmios.url = "github:mlabs-haskell/ogmios/e78fd982e720c93a24607d37c6f6f5188da27929";
+    ogmios.url = "github:mlabs-haskell/ogmios/c4f896bf32ad066be8edd8681ee11e4ab059be7f";
     ogmios-datum-cache = {
       url = "github:mlabs-haskell/ogmios-datum-cache";
       flake = false;

--- a/flake.nix
+++ b/flake.nix
@@ -5,8 +5,10 @@
       flake = false;
     };
 
+    nixpkgs.url = "github:NixOS/nixpkgs/dde1557825c5644c869c5efc7448dc03722a8f09";
+
     # for the purescript project
-    ogmios.url = "github:mlabs-haskell/ogmios";
+    ogmios.url = "github:mlabs-haskell/ogmios/e78fd982e720c93a24607d37c6f6f5188da27929";
     ogmios-datum-cache = {
       url = "github:mlabs-haskell/ogmios-datum-cache";
       flake = false;
@@ -29,7 +31,6 @@
     # for the haskell server
     iohk-nix.url = "github:input-output-hk/iohk-nix";
     haskell-nix.url = "github:L-as/haskell.nix?ref=master";
-    nixpkgs.follows = "haskell-nix/nixpkgs-2105";
     nixpkgs-unstable.follows = "haskell-nix/nixpkgs-unstable";
     cardano-addresses = {
       url =

--- a/server/nix/default.nix
+++ b/server/nix/default.nix
@@ -41,8 +41,6 @@ pkgs.haskell-nix.cabalProject {
       [
         haskellPackages.fourmolu
         hlint
-        entr
-        ghcid
         git
         libsodium-vrf
       ];


### PR DESCRIPTION
Closes #168 

This bumps the version of our fork of Ogmios to v5.2.0 (needed to unblock #131 and #167). Haskell.nix has also been bumped out of necessity