### PR TITLE
Configurable port for Haskell server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,6 @@ check-format:
 format:
 	purs-tidy format-in-place "src/**/*.purs" "test/**/*.purs" "examples/**/*.purs"
 
-
 run-testnet-node:
 	docker run --rm \
 	  -e NETWORK=testnet \
@@ -27,7 +26,7 @@ run-testnet-ogmios:
 		--node-config "$$CARDANO_NODE_CONFIG"
 
 run-haskell-server:
-	nix run -L .#cardano-browser-tx-server:exe:cardano-browser-tx-server
+	nix run -L .#cbtx-server
 
 run-datum-cache-postgres:
 	docker run -d --rm \

--- a/flake.nix
+++ b/flake.nix
@@ -164,11 +164,14 @@
         self.hsFlake.${system}.packages // (psProjectFor system).packages
       );
 
-      apps = perSystem (system: {
-        inherit
-          (self.hsFlake.${system}.apps)
-          "cardano-browser-tx-server:exe:cardano-browser-tx-server";
-      });
+      apps = perSystem (system:
+        let
+          serverApp = "cardano-browser-tx-server:exe:cardano-browser-tx-server";
+        in
+        {
+          cbtx-server = self.hsFlake.${system}.apps.${serverApp};
+        }
+      );
 
       defaultPackage = perSystem (system: (psProjectFor system).defaultPackage);
 

--- a/server/cardano-browser-tx-server.cabal
+++ b/server/cardano-browser-tx-server.cabal
@@ -86,6 +86,7 @@ executable cardano-browser-tx-server
     , base
     , cardano-browser-tx-server
     , http-types
+    , optparse-applicative
     , wai
     , wai-logger
     , warp

--- a/server/exe/Main.hs
+++ b/server/exe/Main.hs
@@ -1,10 +1,14 @@
+{-# LANGUAGE NamedFieldPuns #-}
+
 module Main (main) where
 
 import Api (app)
+import Control.Applicative ((<**>))
 import Data.Function ((&))
 import Network.HTTP.Types (Status)
 import Network.Wai (Request)
 import Network.Wai.Handler.Warp (
+  Port,
   Settings,
   defaultSettings,
   runSettings,
@@ -12,15 +16,36 @@ import Network.Wai.Handler.Warp (
   setPort,
  )
 import Network.Wai.Logger (withStdoutLogger)
+import Options.Applicative qualified as Options
 import System.Exit (die)
-import Types (newEnvIO)
+import Types (ServerOptions (ServerOptions, port), newEnvIO)
 
 main :: IO ()
-main = withStdoutLogger $ \logger ->
-  runSettings (mkSettings logger)
-    . app
-    =<< either die pure
-    =<< newEnvIO
+main = do
+  ServerOptions {port} <- Options.execParser opts
+  withStdoutLogger $ \logger ->
+    runSettings (mkSettings port logger)
+      . app
+      =<< either die pure
+      =<< newEnvIO
   where
-    mkSettings :: (Request -> Status -> Maybe Integer -> IO ()) -> Settings
-    mkSettings logger = defaultSettings & setPort 8081 & setLogger logger
+    mkSettings ::
+      Port -> (Request -> Status -> Maybe Integer -> IO ()) -> Settings
+    mkSettings port logger = defaultSettings & setPort port & setLogger logger
+
+opts :: Options.ParserInfo ServerOptions
+opts =
+  Options.info (serverOptions <**> Options.helper) $
+    Options.fullDesc <> Options.progDesc "CBTx server"
+
+serverOptions :: Options.Parser ServerOptions
+serverOptions =
+  ServerOptions
+    <$> Options.option
+      Options.auto
+      ( Options.long "port"
+          <> Options.help "Server port"
+          <> Options.showDefault
+          <> Options.value 8081
+          <> Options.metavar "INT"
+      )

--- a/server/exe/Main.hs
+++ b/server/exe/Main.hs
@@ -23,7 +23,8 @@ import Types (ServerOptions (ServerOptions, port), newEnvIO)
 main :: IO ()
 main = do
   ServerOptions {port} <- Options.execParser opts
-  withStdoutLogger $ \logger ->
+  withStdoutLogger $ \logger -> do
+    putStrLn $ "CBTx server starting on port " <> show port
     runSettings (mkSettings port logger)
       . app
       =<< either die pure

--- a/server/exe/Main.hs
+++ b/server/exe/Main.hs
@@ -37,7 +37,9 @@ main = do
 opts :: Options.ParserInfo ServerOptions
 opts =
   Options.info (serverOptions <**> Options.helper) $
-    Options.fullDesc <> Options.progDesc "CBTx server"
+    Options.fullDesc
+      <> Options.progDesc
+        "CBTx server. See the README for routes and request/response types"
 
 serverOptions :: Options.Parser ServerOptions
 serverOptions =
@@ -45,6 +47,7 @@ serverOptions =
     <$> Options.option
       Options.auto
       ( Options.long "port"
+          <> Options.short 'p'
           <> Options.help "Server port"
           <> Options.showDefault
           <> Options.value 8081

--- a/server/nix/default.nix
+++ b/server/nix/default.nix
@@ -25,6 +25,7 @@ pkgs.haskell-nix.cabalProject {
       cardano-ledger-shelley
       cardano-ledger-shelley-ma
       cardano-prelude
+      optparse-applicative
       plutus-tx
       plutus-ledger-api
     ];

--- a/server/src/Types.hs
+++ b/server/src/Types.hs
@@ -1,5 +1,6 @@
 module Types (
   AppM (AppM),
+  ServerOptions (..),
   Env (..),
   Cbor (..),
   Fee (..),
@@ -29,6 +30,7 @@ import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import Data.Text qualified as Text
 import GHC.Generics (Generic)
+import Network.Wai.Handler.Warp (Port)
 import Paths_cardano_browser_tx_server (getDataFileName)
 import Plutus.V1.Ledger.Api qualified as Ledger
 import Servant (FromHttpApiData, QueryParam', Required, ToHttpApiData)
@@ -48,6 +50,11 @@ newtype AppM (a :: Type) = AppM (ReaderT Env IO a)
 
 newtype Env = Env
   { protocolParams :: Shelley.ProtocolParameters
+  }
+  deriving stock (Generic)
+
+newtype ServerOptions = ServerOptions
+  { port :: Port
   }
   deriving stock (Generic)
 


### PR DESCRIPTION
Closes #195. `8081` is still the default, but the server now takes an optional `--port`/`-p` argument

I also took this as an opportunity to make some small improvements to the server and related project setup:
- the server app's name in the `apps` output has been simplified (Makefile also updated)
- a message is logged to the console when starting the server (otherwise it can be difficult to know when the build has finished)