### PR TITLE
Viet/remove hash script lookups

### DIFF
--- a/examples/nami/Pkh2Pkh.purs
+++ b/examples/nami/Pkh2Pkh.purs
@@ -59,8 +59,8 @@ import QueryM
   , mkOgmiosWebSocketAff
   , mkDatumCacheWebSocketAff
   , submitTransaction
-  , utxosAt
   )
+import QueryM.Utxos (utxosAt)
 import Serialization.Address (NetworkId(TestnetId))
 import Types.Transaction
   ( Transaction(Transaction)

--- a/src/BalanceTx.purs
+++ b/src/BalanceTx.purs
@@ -54,8 +54,8 @@ import QueryM
   , getWalletAddress
   , getWalletCollateral
   , signTransaction
-  , utxosAt
   )
+import QueryM.Utxos (utxosAt)
 import Serialization.Address
   ( Address
   , addressPaymentCred

--- a/src/Contract/Address.purs
+++ b/src/Contract/Address.purs
@@ -9,6 +9,7 @@ module Contract.Address
   , module ByteArray
   , module JsonWsp
   , module Scripts
+  , module ContractScripts
   , module SerializationAddress
   , module Transaction
   , module UnbalancedTransaction
@@ -23,6 +24,10 @@ import Address
   , ogmiosAddressToAddress
   ) as Address
 import Contract.Monad (Contract)
+import Contract.Scripts
+  ( validatorAddress
+  , validatorBaseAddress
+  ) as ContractScripts
 import Data.Maybe (Maybe)
 import Data.Newtype (wrap)
 import QueryM
@@ -34,8 +39,6 @@ import QueryM
 import Scripts
   ( typedValidatorAddress
   , typedValidatorBaseAddress
-  , validatorAddress
-  , validatorBaseAddress
   , validatorHashAddress
   , validatorHashBaseAddress
   ) as Scripts

--- a/src/Contract/PlutusData.purs
+++ b/src/Contract/PlutusData.purs
@@ -12,7 +12,7 @@ module Contract.PlutusData
   , getDatumsByHashes
   , startFetchBlocksRequest
   , module Datum
-  , module ExportedQueryM
+  , module ExportQueryM
   , module PlutusData
   , module Redeemer
   , module FromData
@@ -41,7 +41,7 @@ import QueryM
   , DatumCacheWebSocket
   , defaultDatumCacheWsConfig
   , mkDatumCacheWebSocketAff
-  ) as ExportedQueryM
+  ) as ExportQueryM
 import Serialization.Address (Slot, BlockId)
 import ToData (class ToData, toData) as ToData
 import Types.PlutusData

--- a/src/Contract/ScriptLookups.purs
+++ b/src/Contract/ScriptLookups.purs
@@ -25,8 +25,10 @@ import Types.ScriptLookups
   ( MkUnbalancedTxError(..) -- A lot errors so will refrain from explicit names.
   , ScriptLookups(ScriptLookups)
   , generalise
+  , mintingPolicy
   , mintingPolicyM
   , otherDataM
+  , otherScript
   , otherScriptM
   , ownPaymentPubKeyHash
   , ownPaymentPubKeyHashM
@@ -35,9 +37,7 @@ import Types.ScriptLookups
   , paymentPubKeyM
   , typedValidatorLookups
   , typedValidatorLookupsM
-  , unsafeMintingPolicyM
   , unsafeOtherDataM
-  , unsafeOtherScriptM
   , unsafePaymentPubKey
   , unspentOutputs
   , unspentOutputsM

--- a/src/Contract/Scripts.purs
+++ b/src/Contract/Scripts.purs
@@ -24,7 +24,13 @@ import Address
   , addressStakeValidatorHash
   , addressValidatorHash
   ) as Address
-import QueryM (ClientError(..)) as ExportQueryM
+import QueryM
+  ( ClientError
+      ( ClientHttpError
+      , ClientDecodeJsonError
+      , ClientEncodingError
+      )
+  ) as ExportQueryM
 import QueryM (applyArgs) as QueryM
 import Scripts
   ( typedValidatorAddress

--- a/src/Contract/Scripts.purs
+++ b/src/Contract/Scripts.purs
@@ -4,10 +4,16 @@
 module Contract.Scripts
   ( applyArgs
   , applyArgsM
+  , mintingPolicyHash
+  , scriptHash
+  , stakeValidatorHash
+  , validatorAddress
+  , validatorBaseAddress
+  , validatorHash
   , module Address
-  , module ExportedQueryM
+  , module ExportQueryM
+  , module ExportScripts
   , module Hash
-  , module Scripts
   , module TypedValidator
   , module TypesScripts
   ) where
@@ -18,19 +24,21 @@ import Address
   , addressStakeValidatorHash
   , addressValidatorHash
   ) as Address
-import QueryM (ClientError(..)) as ExportedQueryM
+import QueryM (ClientError(..)) as ExportQueryM
 import QueryM (applyArgs) as QueryM
+import Scripts
+  ( typedValidatorAddress
+  , typedValidatorBaseAddress
+  , validatorHashAddress
+  , validatorHashBaseAddress
+  ) as ExportScripts
 import Scripts
   ( mintingPolicyHash
   , scriptHash
   , stakeValidatorHash
-  , typedValidatorAddress
-  , typedValidatorBaseAddress
   , validatorAddress
   , validatorBaseAddress
   , validatorHash
-  , validatorHashAddress
-  , validatorHashBaseAddress
   ) as Scripts
 import Serialization.Hash -- Includes low level helpers. Do we want these?
   ( Ed25519KeyHash
@@ -74,8 +82,17 @@ import Data.Argonaut (class DecodeJson)
 import Data.Either (Either, hush)
 import Data.Maybe (Maybe)
 import Data.Newtype (class Newtype, wrap)
+import Serialization.Address (Address, BaseAddress)
 import Types.PlutusData (PlutusData)
-import Types.Scripts (PlutusScript)
+import Types.Scripts
+  ( MintingPolicy
+  , MintingPolicyHash
+  , PlutusScript
+  , StakeValidator
+  , StakeValidatorHash
+  , Validator
+  , ValidatorHash
+  )
 
 -- | Apply `PlutusData` arguments to any type isomorphic to `PlutusScript`,
 -- | returning an updated script with the provided arguments applied
@@ -85,7 +102,7 @@ applyArgs
   => DecodeJson a
   => a
   -> Array PlutusData
-  -> Contract (Either ExportedQueryM.ClientError a)
+  -> Contract (Either ExportQueryM.ClientError a)
 applyArgs a = wrap <<< QueryM.applyArgs a
 
 -- | Same as `applyArgs` with arguments hushed.
@@ -97,3 +114,21 @@ applyArgsM
   -> Array PlutusData
   -> Contract (Maybe a)
 applyArgsM a = map hush <<< applyArgs a
+
+mintingPolicyHash :: MintingPolicy -> Contract (Maybe MintingPolicyHash)
+mintingPolicyHash = wrap <<< Scripts.mintingPolicyHash
+
+scriptHash :: PlutusScript -> Contract (Maybe Hash.ScriptHash)
+scriptHash = wrap <<< Scripts.scriptHash
+
+stakeValidatorHash :: StakeValidator -> Contract (Maybe StakeValidatorHash)
+stakeValidatorHash = wrap <<< Scripts.stakeValidatorHash
+
+validatorHash :: Validator -> Contract (Maybe ValidatorHash)
+validatorHash = wrap <<< Scripts.validatorHash
+
+validatorAddress :: Validator -> Contract (Maybe Address)
+validatorAddress = wrap <<< Scripts.validatorAddress
+
+validatorBaseAddress :: Validator -> Contract (Maybe BaseAddress)
+validatorBaseAddress = wrap <<< Scripts.validatorBaseAddress

--- a/src/Contract/Utxos.purs
+++ b/src/Contract/Utxos.purs
@@ -11,7 +11,7 @@ import Prelude
 import Contract.Monad (Contract)
 import Data.Maybe (Maybe)
 import Data.Newtype (wrap)
-import QueryM (utxosAt) as QueryM
+import QueryM.Utxos (utxosAt) as Utxos
 import Serialization.Address (Address)
 -- Can potentially remove, perhaps we move utxo related all to Contract.Address
 -- and/or Contract.Transaction. Perhaps it's best to not expose JsonWsp.
@@ -24,4 +24,4 @@ import Types.Transaction (Utxo, UtxoM(UtxoM)) as Transaction
 -- | Results may vary depending on `Wallet` type. See `QueryM` for more details
 -- | on wallet variance.
 utxosAt :: Address -> Contract (Maybe Transaction.UtxoM)
-utxosAt = wrap <<< QueryM.utxosAt
+utxosAt = wrap <<< Utxos.utxosAt

--- a/src/QueryM.purs
+++ b/src/QueryM.purs
@@ -1,10 +1,10 @@
 -- | TODO docstring
 module QueryM
-  ( DatumCacheListeners
+  ( ClientError(..)
+  , DatumCacheListeners
   , DatumCacheWebSocket
   , DispatchIdMap
   , FeeEstimate(..)
-  , ClientError(..)
   , Host
   , JsWebSocket
   , ListenerSet
@@ -14,6 +14,9 @@ module QueryM
   , QueryM
   , ServerConfig
   , WebSocket
+  , _stringify
+  , _wsSend
+  , allowError
   , applyArgs
   , calculateMinFee
   , cancelFetchBlocksRequest
@@ -29,6 +32,7 @@ module QueryM
   , getDatumsByHashes
   , getWalletAddress
   , getWalletCollateral
+  , listeners
   , mkDatumCacheWebSocketAff
   , mkHttpUrl
   , mkOgmiosWebSocketAff
@@ -39,12 +43,11 @@ module QueryM
   , signTransaction
   , startFetchBlocksRequest
   , submitTransaction
-  , utxosAt
+  , underlyingWebSocket
   ) where
 
 import Prelude
 
-import Address (addressToOgmiosAddress)
 import Aeson as Aeson
 import Affjax as Affjax
 import Affjax.ResponseFormat as Affjax.ResponseFormat
@@ -58,14 +61,12 @@ import Data.Argonaut.Encode.Encoders (encodeString)
 import Data.Bifunctor (bimap, lmap)
 import Data.BigInt (BigInt)
 import Data.BigInt as BigInt
-import Data.Bitraversable (bisequence)
 import Data.Either (Either(Left, Right), either, isRight, note)
 import Data.Foldable (foldl)
-import Data.Map as Map
 import Data.Maybe (Maybe(Just, Nothing), maybe)
 import Data.Newtype (class Newtype, unwrap, wrap)
-import Data.Traversable (sequence, traverse)
-import Data.Tuple.Nested (type (/\), (/\))
+import Data.Traversable (traverse)
+import Data.Tuple.Nested ((/\))
 import Data.UInt (UInt)
 import Data.UInt as UInt
 import DatumCacheWsp
@@ -125,7 +126,6 @@ import Types.Transaction as Transaction
 import Types.TransactionUnspentOutput (TransactionUnspentOutput)
 import Types.UnbalancedTransaction (PubKeyHash, PaymentPubKeyHash, pubKeyHash)
 import Types.Value (Coin(Coin))
-import TxOutput (ogmiosTxOutToTransactionOutput, txOutRefToTransactionInput)
 import Untagged.Union (asOneOf)
 import UsedTxOuts (UsedTxOuts, isTxOutRefUsed)
 import Wallet (Wallet(Nami), NamiWallet, NamiConnection)
@@ -174,31 +174,6 @@ type QueryConfig =
   }
 
 type QueryM (a :: Type) = ReaderT QueryConfig Aff a
-
--- the first query type in the QueryM/Aff interface
-utxosAt' :: JsonWsp.OgmiosAddress -> QueryM JsonWsp.UtxoQR
-utxosAt' addr = do
-  body <- liftEffect $ JsonWsp.mkUtxosAtQuery { utxo: [ addr ] }
-  let id = body.mirror.id
-  sBody <- liftEffect $ _stringify body
-  config <- ask
-  -- not sure there's an easy way to factor this out unfortunately
-  let
-    affFunc :: (Either Error JsonWsp.UtxoQR -> Effect Unit) -> Effect Canceler
-    affFunc cont = do
-      let
-        ls = listeners config.ogmiosWs
-        ws = underlyingWebSocket config.ogmiosWs
-      ls.utxo.addMessageListener id
-        ( \result -> do
-            ls.utxo.removeMessageListener id
-            allowError cont $ result
-        )
-      _wsSend ws sBody
-      pure $ Canceler $ \err -> do
-        liftEffect $ ls.utxo.removeMessageListener id
-        liftEffect $ throwError $ err
-  liftAff $ makeAff $ affFunc
 
 --------------------------------------------------------------------------------
 -- Used Utxos helpers
@@ -692,58 +667,3 @@ messageFoldF
 messageFoldF msg acc' func = do
   acc <- acc'
   if isRight acc then acc' else func msg
-
---------------------------------------------------------------------------------
--- Ogmios functions
---------------------------------------------------------------------------------
-
--- If required, we can change to Either with more granular error handling.
--- | Gets utxos at an (internal) `Address` in terms of (internal) `Transaction.Types`.
--- | Results may vary depending on `Wallet` type.
-utxosAt :: Address -> QueryM (Maybe Transaction.UtxoM)
-utxosAt addr = asks _.wallet >>= maybe (pure Nothing) (utxosAtByWallet addr)
-  where
-  -- Add more wallet types here:
-  utxosAtByWallet
-    :: Address -> Wallet -> QueryM (Maybe Transaction.UtxoM)
-  utxosAtByWallet address (Nami _) = namiUtxosAt address
-  -- Unreachable but helps build when we add wallets, most of them shouldn't
-  -- require any specific behaviour.
-  utxosAtByWallet address _ = allUtxosAt address
-
-  -- Gets all utxos at an (internal) Address in terms of (internal)
-  -- Transaction.Types.
-  allUtxosAt :: Address -> QueryM (Maybe Transaction.UtxoM)
-  allUtxosAt = addressToOgmiosAddress >>> getUtxos
-    where
-    getUtxos :: JsonWsp.OgmiosAddress -> QueryM (Maybe Transaction.UtxoM)
-    getUtxos address = convertUtxos <$> utxosAt' address
-
-    convertUtxos :: JsonWsp.UtxoQR -> Maybe Transaction.UtxoM
-    convertUtxos (JsonWsp.UtxoQR utxoQueryResult) =
-      let
-        out' :: Array (Maybe Transaction.TransactionInput /\ Maybe Transaction.TransactionOutput)
-        out' = Map.toUnfoldable utxoQueryResult
-          <#> bimap
-            txOutRefToTransactionInput
-            ogmiosTxOutToTransactionOutput
-
-        out :: Maybe (Array (Transaction.TransactionInput /\ Transaction.TransactionOutput))
-        out = out' <#> bisequence # sequence
-      in
-        (wrap <<< Map.fromFoldable) <$> out
-
-  -- Nami appear to remove collateral from the utxo set, so we shall do the same.
-  -- This is crucial if we are submitting via Nami. If we decide to submit with
-  -- Ogmios, we can remove this.
-  -- More detail can be found here https://github.com/Berry-Pool/nami-wallet/blob/ecb32e39173b28d4a7a85b279a748184d4759f6f/src/api/extension/index.js
-  -- by searching "// exclude collateral input from overall utxo set"
-  -- or functions getUtxos and checkCollateral.
-  namiUtxosAt :: Address -> QueryM (Maybe Transaction.UtxoM)
-  namiUtxosAt address = do
-    utxos' <- allUtxosAt address
-    collateral' <- getWalletCollateral
-    pure do
-      utxos <- unwrap <$> utxos'
-      collateral <- unwrap <$> collateral'
-      pure $ wrap $ Map.delete collateral.input utxos

--- a/src/QueryM/Utxos.purs
+++ b/src/QueryM/Utxos.purs
@@ -1,0 +1,111 @@
+module QueryM.Utxos
+  ( utxosAt
+  ) where
+
+import Prelude
+import Address (addressToOgmiosAddress)
+import Control.Monad.Error.Class (throwError)
+import Control.Monad.Reader.Trans (ask, asks)
+import Data.Bifunctor (bimap)
+import Data.Bitraversable (bisequence)
+import Data.Either (Either)
+import Data.Map as Map
+import Data.Maybe (Maybe(Nothing), maybe)
+import Data.Newtype (unwrap, wrap)
+import Data.Traversable (sequence)
+import Data.Tuple.Nested (type (/\))
+import Effect (Effect)
+import Effect.Aff (Canceler(Canceler), makeAff)
+import Effect.Aff.Class (liftAff)
+import Effect.Class (liftEffect)
+import Effect.Exception (Error)
+import QueryM
+  ( QueryM
+  , _stringify
+  , _wsSend
+  , allowError
+  , getWalletCollateral
+  , listeners
+  , underlyingWebSocket
+  )
+import Serialization.Address (Address)
+import Types.JsonWsp as JsonWsp
+import Types.Transaction as Transaction
+import TxOutput (ogmiosTxOutToTransactionOutput, txOutRefToTransactionInput)
+import Wallet (Wallet(Nami))
+
+-- the first query type in the QueryM/Aff interface
+utxosAt' :: JsonWsp.OgmiosAddress -> QueryM JsonWsp.UtxoQR
+utxosAt' addr = do
+  body <- liftEffect $ JsonWsp.mkUtxosAtQuery { utxo: [ addr ] }
+  let id = body.mirror.id
+  sBody <- liftEffect $ _stringify body
+  config <- ask
+  -- not sure there's an easy way to factor this out unfortunately
+  let
+    affFunc :: (Either Error JsonWsp.UtxoQR -> Effect Unit) -> Effect Canceler
+    affFunc cont = do
+      let
+        ls = listeners config.ogmiosWs
+        ws = underlyingWebSocket config.ogmiosWs
+      ls.utxo.addMessageListener id
+        ( \result -> do
+            ls.utxo.removeMessageListener id
+            allowError cont $ result
+        )
+      _wsSend ws sBody
+      pure $ Canceler $ \err -> do
+        liftEffect $ ls.utxo.removeMessageListener id
+        liftEffect $ throwError $ err
+  liftAff $ makeAff $ affFunc
+
+-- If required, we can change to Either with more granular error handling.
+-- | Gets utxos at an (internal) `Address` in terms of (internal) `Transaction.Types`.
+-- | Results may vary depending on `Wallet` type.
+utxosAt :: Address -> QueryM (Maybe Transaction.UtxoM)
+utxosAt addr = asks _.wallet >>= maybe (pure Nothing) (utxosAtByWallet addr)
+  where
+  -- Add more wallet types here:
+  utxosAtByWallet
+    :: Address -> Wallet -> QueryM (Maybe Transaction.UtxoM)
+  utxosAtByWallet address (Nami _) = namiUtxosAt address
+  -- Unreachable but helps build when we add wallets, most of them shouldn't
+  -- require any specific behaviour.
+  utxosAtByWallet address _ = allUtxosAt address
+
+  -- Gets all utxos at an (internal) Address in terms of (internal)
+  -- Transaction.Types.
+  allUtxosAt :: Address -> QueryM (Maybe Transaction.UtxoM)
+  allUtxosAt = addressToOgmiosAddress >>> getUtxos
+    where
+    getUtxos :: JsonWsp.OgmiosAddress -> QueryM (Maybe Transaction.UtxoM)
+    getUtxos address = convertUtxos <$> utxosAt' address
+
+    convertUtxos :: JsonWsp.UtxoQR -> Maybe Transaction.UtxoM
+    convertUtxos (JsonWsp.UtxoQR utxoQueryResult) =
+      let
+        out' :: Array (Maybe Transaction.TransactionInput /\ Maybe Transaction.TransactionOutput)
+        out' = Map.toUnfoldable utxoQueryResult
+          <#> bimap
+            txOutRefToTransactionInput
+            ogmiosTxOutToTransactionOutput
+
+        out :: Maybe (Array (Transaction.TransactionInput /\ Transaction.TransactionOutput))
+        out = out' <#> bisequence # sequence
+      in
+        (wrap <<< Map.fromFoldable) <$> out
+
+  -- Nami appear to remove collateral from the utxo set, so we shall do the same.
+  -- This is crucial if we are submitting via Nami. If we decide to submit with
+  -- Ogmios, we can remove this.
+  -- More detail can be found here https://github.com/Berry-Pool/nami-wallet/blob/ecb32e39173b28d4a7a85b279a748184d4759f6f/src/api/extension/index.js
+  -- by searching "// exclude collateral input from overall utxo set"
+  -- or functions getUtxos and checkCollateral.
+  namiUtxosAt :: Address -> QueryM (Maybe Transaction.UtxoM)
+  namiUtxosAt address = do
+    utxos' <- allUtxosAt address
+    collateral' <- getWalletCollateral
+    pure do
+      utxos <- unwrap <$> utxos'
+      collateral <- unwrap <$> collateral'
+      pure $ wrap $ Map.delete collateral.input utxos

--- a/src/Scripts.purs
+++ b/src/Scripts.purs
@@ -12,8 +12,10 @@ module Scripts
   ) where
 
 import Prelude
+import Control.Monad.Maybe.Trans (runMaybeT, MaybeT(MaybeT))
 import Data.Maybe (Maybe)
 import Data.Newtype (class Newtype, unwrap, wrap)
+import QueryM (QueryM)
 import Serialization.Address
   ( Address
   , BaseAddress
@@ -25,7 +27,6 @@ import Serialization.Address
   )
 import Serialization.Hash
   ( ScriptHash
-  , scriptHashFromBytes
   , scriptHashToBytes
   )
 import Types.Scripts
@@ -38,23 +39,22 @@ import Types.Scripts
   , ValidatorHash
   )
 import Types.TypedValidator (TypedValidator(TypedValidator))
+import Undefined (undefined)
 
 -- | Helpers for `PlutusScript` and `ScriptHash` newtype wrappers, separate from
 -- | the data type definitions to prevent cylic dependencies.
 
 -- | Converts a Plutus-style `Validator` to a `BaseAddress`
-validatorBaseAddress :: Validator -> Maybe BaseAddress
-validatorBaseAddress =
-  (=<<) baseAddressFromBytes
-    <<< map (scriptHashToBytes <<< unwrap)
-    <<< validatorHash
+validatorBaseAddress :: Validator -> QueryM (Maybe BaseAddress)
+validatorBaseAddress val = runMaybeT do
+  bytes <- MaybeT $ map (scriptHashToBytes <<< unwrap) <$> validatorHash val
+  MaybeT $ pure $ baseAddressFromBytes bytes
 
 -- | Converts a Plutus-style `Validator` to an `Address`
-validatorAddress :: Validator -> Maybe Address
-validatorAddress =
-  (=<<) addressFromBytes
-    <<< map (scriptHashToBytes <<< unwrap)
-    <<< validatorHash
+validatorAddress :: Validator -> QueryM (Maybe Address)
+validatorAddress val = runMaybeT do
+  bytes <- MaybeT $ map (scriptHashToBytes <<< unwrap) <$> validatorHash val
+  MaybeT $ pure $ addressFromBytes bytes
 
 -- | Converts a Plutus-style `TypedValidator` to an `BaseAddress`
 typedValidatorBaseAddress
@@ -69,11 +69,11 @@ typedValidatorAddress networkId =
   baseAddressToAddress <<< typedValidatorBaseAddress networkId
 
 -- | Converts a Plutus-style `MintingPolicy` to an `MintingPolicyHash`
-mintingPolicyHash :: MintingPolicy -> Maybe MintingPolicyHash
+mintingPolicyHash :: MintingPolicy -> QueryM (Maybe MintingPolicyHash)
 mintingPolicyHash = plutusScriptHash
 
 -- | Converts a Plutus-style `Validator` to an `ValidatorHash`
-validatorHash :: Validator -> Maybe ValidatorHash
+validatorHash :: Validator -> QueryM (Maybe ValidatorHash)
 validatorHash = plutusScriptHash
 
 -- | Converts a Plutus-style `ValidatorHash` to a `BaseAddress`
@@ -86,7 +86,7 @@ validatorHashAddress networkId =
   baseAddressToAddress <<< validatorHashBaseAddress networkId
 
 -- | Converts a Plutus-style `StakeValidator` to an `Address`
-stakeValidatorHash :: StakeValidator -> Maybe StakeValidatorHash
+stakeValidatorHash :: StakeValidator -> QueryM (Maybe StakeValidatorHash)
 stakeValidatorHash = plutusScriptHash
 
 plutusScriptHash
@@ -94,9 +94,9 @@ plutusScriptHash
    . Newtype m PlutusScript
   => Newtype n ScriptHash
   => m
-  -> Maybe n
-plutusScriptHash = map wrap <<< scriptHash <<< unwrap
+  -> QueryM (Maybe n)
+plutusScriptHash = map (map wrap) <<< scriptHash <<< unwrap
 
 -- | Converts a `PlutusScript` to a `ScriptHash`.
-scriptHash :: PlutusScript -> Maybe ScriptHash
-scriptHash = scriptHashFromBytes <<< unwrap
+scriptHash :: PlutusScript -> QueryM (Maybe ScriptHash)
+scriptHash = undefined

--- a/src/Scripts.purs
+++ b/src/Scripts.purs
@@ -13,7 +13,7 @@ module Scripts
 
 import Prelude
 import Control.Monad.Maybe.Trans (runMaybeT, MaybeT(MaybeT))
-import Data.Maybe (Maybe)
+import Data.Maybe (Maybe(Nothing), maybe)
 import Data.Newtype (class Newtype, unwrap, wrap)
 import QueryM (QueryM)
 import Serialization.Address
@@ -46,15 +46,15 @@ import Undefined (undefined)
 
 -- | Converts a Plutus-style `Validator` to a `BaseAddress`
 validatorBaseAddress :: Validator -> QueryM (Maybe BaseAddress)
-validatorBaseAddress val = runMaybeT do
-  bytes <- MaybeT $ map (scriptHashToBytes <<< unwrap) <$> validatorHash val
-  MaybeT $ pure $ baseAddressFromBytes bytes
+validatorBaseAddress val =
+  map (scriptHashToBytes <<< unwrap) <$> validatorHash val >>=
+    maybe Nothing baseAddressFromBytes >>> pure
 
 -- | Converts a Plutus-style `Validator` to an `Address`
 validatorAddress :: Validator -> QueryM (Maybe Address)
-validatorAddress val = runMaybeT do
-  bytes <- MaybeT $ map (scriptHashToBytes <<< unwrap) <$> validatorHash val
-  MaybeT $ pure $ addressFromBytes bytes
+validatorAddress val =
+  map (scriptHashToBytes <<< unwrap) <$> validatorHash val >>=
+    maybe Nothing addressFromBytes >>> pure
 
 -- | Converts a Plutus-style `TypedValidator` to an `BaseAddress`
 typedValidatorBaseAddress

--- a/src/Types/ScriptLookups.purs
+++ b/src/Types/ScriptLookups.purs
@@ -520,7 +520,7 @@ runConstraintsM
   => ScriptLookups a
   -> TxConstraints b b
   -> QueryM (Either MkUnbalancedTxError ConstraintProcessingState)
-runConstraintsM scriptLookups txConstraints = do
+runConstraintsM scriptLookups txConstraints =
   let
     config :: ConstraintsConfig a
     config =
@@ -544,10 +544,11 @@ runConstraintsM scriptLookups txConstraints = do
       -> Either MkUnbalancedTxError ConstraintProcessingState
     unpackTuple (Left err /\ _) = Left err
     unpackTuple (_ /\ cps) = Right cps
-  unpackTuple <$>
-    ( flip runStateT initCps $ flip runReaderT config $
-        processLookupsAndConstraints txConstraints
-    )
+  in
+    unpackTuple <$>
+      ( flip runStateT initCps $ flip runReaderT config $
+          processLookupsAndConstraints txConstraints
+      )
 
 -- See comments in `processLookupsAndConstraints` regarding constraints.
 -- | Create an `UnbalancedTx` given `ScriptLookups` and `TxConstraints`.

--- a/src/Types/TypedValidator.purs
+++ b/src/Types/TypedValidator.purs
@@ -87,7 +87,7 @@ newtype TypedValidator (a :: Type) = TypedValidator
   { validator :: Validator
   , validatorHash :: ValidatorHash
   , forwardingMPS :: MintingPolicy
-  , forwardingMPSHash :: MintingPolicyHash
+  , forwardingMPSHash :: MintingPolicyHash -- Can maybe remove as unused in lookups.
   -- The hash of the minting policy that checks whether the validator
   -- is run in this transaction
   }

--- a/test/AffInterface.purs
+++ b/test/AffInterface.purs
@@ -15,8 +15,8 @@ import QueryM
   , defaultServerConfig
   , mkDatumCacheWebSocketAff
   , mkOgmiosWebSocketAff
-  , utxosAt
   )
+import QueryM.Utxos (utxosAt)
 import Test.Spec.Assertions (shouldEqual)
 import TestM (TestPlanM)
 import Types.JsonWsp (OgmiosAddress)


### PR DESCRIPTION
- Closes https://github.com/Plutonomicon/cardano-browser-tx/issues/203
- Started a minimal `QueryM` refactor as part of https://github.com/Plutonomicon/cardano-browser-tx/issues/184 this was necessary due to cyclic dependencies. We'd probably want the refactor to mirror the namespace of `Contract`. E.g. `QueryM.Monad`, `QueryM.Scripts` eventually (or whatever is suitable).
- Wrote a stub function `scriptHash :: PlutusScript -> QueryM (Maybe ScriptHash)` and replaced everything affected. Replace with https://github.com/Plutonomicon/cardano-browser-tx/issues/204
- Script lookups for other scripts and minting policy scripts are now formed by an `Array` instead of `Map` so we don't have to hash inside our `Contract` script lookup helpers: `mintingPolicy` and `otherScript`. The tradeoff is we lose this mapping as we run the constraints to create the unbalanced tx, although it's easy to get this information back.
- Extended `Contract` API to include lifted versions of these hashing/Address functions