### PR TITLE
Viet/add slot config

### DIFF
--- a/examples/nami/Pkh2Pkh.purs
+++ b/examples/nami/Pkh2Pkh.purs
@@ -62,6 +62,7 @@ import QueryM
   )
 import QueryM.Utxos (utxosAt)
 import Serialization.Address (NetworkId(TestnetId))
+import Types.Interval (defaultSlotConfig)
 import Types.Transaction
   ( Transaction(Transaction)
   , TransactionOutput(TransactionOutput)
@@ -87,6 +88,7 @@ main = launchAff_ $ do
     , serverConfig: defaultServerConfig
     , usedTxOuts
     , networkId: TestnetId
+    , slotConfig: defaultSlotConfig
     }
   liftEffect $ Console.log $ show txId
 

--- a/examples/nami/Simple.purs
+++ b/examples/nami/Simple.purs
@@ -25,6 +25,7 @@ import QueryM
   , defaultServerConfig
   )
 import Serialization.Address (NetworkId(TestnetId))
+import Types.Interval (defaultSlotConfig)
 import UsedTxOuts (newUsedTxOuts)
 import Wallet (mkNamiWalletAff)
 
@@ -40,6 +41,7 @@ main = launchAff_ $ do
     , serverConfig: defaultServerConfig
     , usedTxOuts
     , networkId: TestnetId
+    , slotConfig: defaultSlotConfig
     }
   where
   walletActions :: QueryM Unit

--- a/src/Contract/Monad.purs
+++ b/src/Contract/Monad.purs
@@ -4,6 +4,7 @@ module Contract.Monad
   , ContractConfig(..)
   , defaultContractConfig
   , defaultContractConfigLifted
+  , module Interval
   , module QueryM
   , runContract
   , runContract_
@@ -45,6 +46,7 @@ import QueryM
   , mkWsUrl
   ) as QueryM
 import Serialization.Address (NetworkId(TestnetId))
+import Types.Interval (defaultSlotConfig) as Interval
 import UsedTxOuts (newUsedTxOuts)
 import Wallet (mkNamiWalletAff)
 
@@ -131,6 +133,7 @@ defaultContractConfig = do
     , serverConfig: QueryM.defaultServerConfig
     , usedTxOuts
     , networkId: TestnetId
+    , slotConfig: Interval.defaultSlotConfig
     }
 
 -- | Same as `defaultContractConfig` but lifted into `Contract`.

--- a/src/QueryM.purs
+++ b/src/QueryM.purs
@@ -118,6 +118,7 @@ import Serialization.Hash (ScriptHash)
 import Serialization.PlutusData (convertPlutusData)
 import Types.ByteArray (byteArrayToHex)
 import Types.Datum (DatumHash)
+import Types.Interval (SlotConfig)
 import Types.JsonWsp as JsonWsp
 import Types.PlutusData (PlutusData)
 import Types.Scripts (PlutusScript)
@@ -171,6 +172,7 @@ type QueryConfig =
   -- should probably be more tightly coupled with a wallet
   , usedTxOuts :: UsedTxOuts
   , networkId :: NetworkId
+  , slotConfig :: SlotConfig
   }
 
 type QueryM (a :: Type) = ReaderT QueryConfig Aff a

--- a/src/Types/ScriptLookups.purs
+++ b/src/Types/ScriptLookups.purs
@@ -406,8 +406,7 @@ _redeemers
 _redeemers = prop (SProxy :: SProxy "redeemers")
 
 _lookups
-  :: forall (a :: Type)
-   . Lens' (ConstraintProcessingState a) (ScriptLookups a)
+  :: forall (a :: Type). Lens' (ConstraintProcessingState a) (ScriptLookups a)
 _lookups = prop (SProxy :: SProxy "lookups")
 
 missingValueSpent :: ValueSpentBalances -> Value

--- a/test/AffInterface.purs
+++ b/test/AffInterface.purs
@@ -20,6 +20,7 @@ import QueryM.Utxos (utxosAt)
 import Serialization.Address (NetworkId(TestnetId))
 import Test.Spec.Assertions (shouldEqual)
 import TestM (TestPlanM)
+import Types.Interval (defaultSlotConfig)
 import Types.JsonWsp (OgmiosAddress)
 import UsedTxOuts (newUsedTxOuts)
 
@@ -62,6 +63,7 @@ testUtxosAt testAddr = do
       , wallet: Nothing
       , usedTxOuts
       , networkId: TestnetId
+      , slotConfig: defaultSlotConfig
       }
 
 testFromOgmiosAddress :: OgmiosAddress -> Aff Unit


### PR DESCRIPTION
Closes https://github.com/Plutonomicon/cardano-browser-tx/issues/216
- Move slot config to underlying `ReaderT` config for a single source of truth.
- Change `Constraints a` into `ScriptLookups a` (still treating as immutable).