### PR TITLE
Fix bug with converting tx body

### DIFF
--- a/src/Serialization.js
+++ b/src/Serialization.js
@@ -134,3 +134,9 @@ exports.newRedeemers = () =>
 
 exports.addRedeemer = rs => r => () =>
     rs.add(r);
+
+exports.newScriptDataHashFromBytes = bytes => () =>
+    lib.ScriptDataHash.from_bytes(bytes);
+
+exports.setTxBodyScriptDataHash = body => sdh => () =>
+    body.set_script_data_hash(sdh)

--- a/src/Serialization.purs
+++ b/src/Serialization.purs
@@ -119,6 +119,8 @@ foreign import newInt32 :: Int -> Effect Int32
 foreign import _hashScriptData :: Redeemers -> Costmdls -> PlutusList -> Effect ScriptDataHash
 foreign import newRedeemers :: Effect Redeemers
 foreign import addRedeemer :: Redeemers -> Redeemer -> Effect Unit
+foreign import newScriptDataHashFromBytes :: ByteArray -> Effect ScriptDataHash
+foreign import setTxBodyScriptDataHash :: TransactionBody -> ScriptDataHash -> Effect TransactionBody
 
 foreign import toBytes
   :: ( Transaction
@@ -139,6 +141,9 @@ convertTransaction (T.Transaction { body: T.TxBody body, witness_set }) = do
   outputs <- convertTxOutputs body.outputs
   fee <- maybe (throw "Failed to convert fee") pure $ bigNumFromBigInt (unwrap body.fee)
   txBody <- newTransactionBody inputs outputs fee
+  traverse_
+    (unwrap >>> newScriptDataHashFromBytes >=> setTxBodyScriptDataHash txBody)
+    body.script_data_hash
   ws <- convertWitnessSet witness_set
   newTransaction txBody ws
 


### PR DESCRIPTION
Discovered in the course of fixing #219. Previously, converting the tx body would fail to preserve the script data hash