### PR TITLE
Fix for tuple instance

### DIFF
--- a/src/ToData.purs
+++ b/src/ToData.purs
@@ -16,6 +16,7 @@ import Data.Map as Map
 import Data.Maybe (Maybe(Just, Nothing))
 import Data.Profunctor.Strong ((***))
 import Data.Ratio (Ratio, denominator, numerator)
+import Data.Tuple (Tuple(Tuple))
 import Data.Tuple.Nested (type (/\), (/\))
 import Data.UInt (UInt)
 import Helpers (uIntToBigInt)
@@ -59,8 +60,8 @@ instance ToData a => ToData (Array a) where
 instance ToData a => ToData (List a) where
   toData = foldableToPlutusData
 
-instance (ToData a, ToData b) => ToData (a /\ b) where
-  toData (a /\ b) = Constr zero [ toData a, toData b ]
+instance (ToData a, ToData b) => ToData (Tuple a b) where
+  toData (Tuple a b) = Constr zero [ toData a, toData b ]
 
 instance (ToData k, ToData v) => ToData (Map k v) where
   toData mp = Map $ entries # map (toData *** toData) # Map.fromFoldable


### PR DESCRIPTION
This is a "fix" for the `a /\ b` `ToData` instance. Using the `/\` type constructor causes webpack to freak out:

```
ERROR in ./output/bundle.js 8072:10
Module parse failed: Unterminated string constant (8072:10)
You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
|   exports["toDataBigInt"] = toDataBigInt;
|   exports["toDataUInt"] = toDataUInt;
>   exports["toData/\"] = toData$div$bslash;
|   exports["toDataByteArray"] = toDataByteArray;
| })(PS);
 @ ./examples/Seabug/Test.purs 1:0-65
 @ ./examples/index.js 4:0-28

```