### PR TITLE
Fix `ownPaymentPubKeyHash`

### DIFF
--- a/examples/Seabug/Contract/MarketPlaceBuy.purs
+++ b/examples/Seabug/Contract/MarketPlaceBuy.purs
@@ -66,7 +66,7 @@ import Seabug.Types
 
 marketplaceBuy :: NftData -> Contract Unit
 marketplaceBuy nftData = do
-  unbalancedTx /\  curr /\ newName  <- mkMarketplaceTx nftData
+  unbalancedTx /\ curr /\ newName <- mkMarketplaceTx nftData
   log "marketplaceBuy: Unbalanced transaction successfully built"
   -- Balance unbalanced tx:
   balancedTx <- liftedE' $ balanceTx unbalancedTx

--- a/examples/Seabug/Test.purs
+++ b/examples/Seabug/Test.purs
@@ -2,6 +2,7 @@ module Seabug.Test (main) where
 
 import Contract.Prelude
 
+import Contract.Address (getWalletAddress)
 import Contract.Monad
   ( Contract
   , defaultContractConfig
@@ -20,6 +21,7 @@ import Contract.Value (mkCurrencySymbol, mkTokenName)
 import Data.BigInt as BigInt
 import Data.UInt as UInt
 import Effect.Aff (launchAff_)
+import Effect.Aff.Class (liftAff)
 import Seabug.Contract.MarketPlaceBuy (mkMarketplaceTx)
 import Seabug.Types
 import Serialization as Serialization
@@ -28,8 +30,11 @@ import Untagged.Union (asOneOf)
 
 main :: Effect Unit
 main = launchAff_ $ do
+  log "hey"
   cfg <- defaultContractConfig
   runContract_ cfg $ do
+    log "foo"
+    log <<< show =<< getWalletAddress
     UnbalancedTx { transaction } /\ _ <- mkMarketplaceTx =<< testNftData
     log =<<
       ( liftEffect

--- a/src/Contract/Address.purs
+++ b/src/Contract/Address.purs
@@ -71,12 +71,11 @@ import Types.UnbalancedTransaction
   , ScriptOutput(ScriptOutput)
   , StakeKeyHash(StakeKeyHash)
   , StakePubKeyHash(StakePubKeyHash)
-  , payPubKeyHash
   , payPubKeyHashAddress
   , payPubKeyHashBaseAddress
   , payPubKeyRequiredSigner
   , payPubKeyVkey
-  , pubKeyHash
+  -- , pubKeyHash
   , pubKeyHashAddress
   , pubKeyHashBaseAddress
   , stakeKeyHashAddress

--- a/src/Contract/ScriptLookups.purs
+++ b/src/Contract/ScriptLookups.purs
@@ -34,11 +34,11 @@ import Types.ScriptLookups
   , ownPaymentPubKeyHashM
   , ownStakePubKeyHash
   , ownStakePubKeyHashM
-  , paymentPubKeyM
+  -- , paymentPubKeyM
   , typedValidatorLookups
   , typedValidatorLookupsM
   , unsafeOtherDataM
-  , unsafePaymentPubKey
+  -- , unsafePaymentPubKey
   , unspentOutputs
   , unspentOutputsM
   ) as ScriptLookups

--- a/src/QueryM.purs
+++ b/src/QueryM.purs
@@ -113,7 +113,8 @@ import Serialization.Address
   , BlockId
   , NetworkId
   , Slot
-  , addressBech32
+  , addressPaymentCred
+  , stakeCredentialToKeyHash
   )
 import Serialization.Hash (ScriptHash)
 import Serialization.PlutusData (convertPlutusData)
@@ -125,7 +126,7 @@ import Types.PlutusData (PlutusData)
 import Types.Scripts (PlutusScript)
 import Types.Transaction as Transaction
 import Types.TransactionUnspentOutput (TransactionUnspentOutput)
-import Types.UnbalancedTransaction (PubKeyHash, PaymentPubKeyHash, pubKeyHash)
+import Types.UnbalancedTransaction (PubKeyHash, PaymentPubKeyHash)
 import Types.Value (Coin(Coin))
 import Untagged.Union (asOneOf)
 import Wallet (Wallet(Nami), NamiWallet, NamiConnection)
@@ -280,7 +281,8 @@ submitTransaction tx = withMWalletAff $ case _ of
 
 ownPubKeyHash :: QueryM (Maybe PubKeyHash)
 ownPubKeyHash =
-  map ((=<<) pubKeyHash <<< map (wrap <<< addressBech32)) getWalletAddress
+  map (map wrap <<< (=<<) (stakeCredentialToKeyHash <=< addressPaymentCred))
+    getWalletAddress
 
 ownPaymentPubKeyHash :: QueryM (Maybe PaymentPubKeyHash)
 ownPaymentPubKeyHash = map wrap <$> ownPubKeyHash

--- a/src/Types/ScriptLookups.purs
+++ b/src/Types/ScriptLookups.purs
@@ -13,11 +13,11 @@ module Types.ScriptLookups
   , ownPaymentPubKeyHashM
   , ownStakePubKeyHash
   , ownStakePubKeyHashM
-  , paymentPubKeyM
+  -- , paymentPubKeyM
   , typedValidatorLookups
   , typedValidatorLookupsM
   , unsafeOtherDataM
-  , unsafePaymentPubKey
+  -- , unsafePaymentPubKey
   , unspentOutputs
   , unspentOutputsM
   ) where
@@ -141,7 +141,7 @@ import Types.UnbalancedTransaction
   , _transaction
   , _utxoIndex
   , emptyUnbalancedTx
-  , payPubKeyHash
+  -- , payPubKeyHash
   , payPubKeyHashAddress
   , payPubKeyRequiredSigner
   , stakePubKeyHashAddress
@@ -298,19 +298,19 @@ otherDataM dt = do
 unsafeOtherDataM :: forall (a :: Type). Datum -> ScriptLookups a
 unsafeOtherDataM = unsafePartial fromJust <<< otherDataM
 
--- | A script lookups value with a payment public key. This can fail because we
--- | invoke `payPubKeyHash`.
-paymentPubKeyM :: forall (a :: Type). PaymentPubKey -> Maybe (ScriptLookups a)
-paymentPubKeyM ppk = do
-  pkh <- payPubKeyHash ppk
-  pure $ over ScriptLookups
-    _ { paymentPubKeyHashes = singleton pkh ppk }
-    mempty
+-- -- | A script lookups value with a payment public key. This can fail because we
+-- -- | invoke `payPubKeyHash`.
+-- paymentPubKeyM :: forall (a :: Type). PaymentPubKey -> Maybe (ScriptLookups a)
+-- paymentPubKeyM ppk = do
+--   pkh <- payPubKeyHash ppk
+--   pure $ over ScriptLookups
+--     _ { paymentPubKeyHashes = singleton pkh ppk }
+--     mempty
 
--- | A script lookups value with a payment public key. This is unsafe because
--- | the underlying function `paymentPubKeyM` can fail.
-unsafePaymentPubKey :: forall (a :: Type). PaymentPubKey -> ScriptLookups a
-unsafePaymentPubKey = unsafePartial fromJust <<< paymentPubKeyM
+-- -- | A script lookups value with a payment public key. This is unsafe because
+-- -- | the underlying function `paymentPubKeyM` can fail.
+-- unsafePaymentPubKey :: forall (a :: Type). PaymentPubKey -> ScriptLookups a
+-- unsafePaymentPubKey = unsafePartial fromJust <<< paymentPubKeyM
 
 -- | Add your own `PaymentPubKeyHash` to the lookup.
 ownPaymentPubKeyHash :: forall (a :: Type). PaymentPubKeyHash -> ScriptLookups a

--- a/src/Types/UnbalancedTransaction.purs
+++ b/src/Types/UnbalancedTransaction.purs
@@ -10,12 +10,12 @@ module Types.UnbalancedTransaction
   , _transaction
   , _utxoIndex
   , emptyUnbalancedTx
-  , payPubKeyHash
+  -- , payPubKeyHash
   , payPubKeyHashAddress
   , payPubKeyHashBaseAddress
   , payPubKeyRequiredSigner
   , payPubKeyVkey
-  , pubKeyHash
+  -- , pubKeyHash
   , pubKeyHashAddress
   , pubKeyHashBaseAddress
   , stakeKeyHashAddress
@@ -38,8 +38,7 @@ import Data.Generic.Rep (class Generic)
 import Data.Lens (lens')
 import Data.Lens.Types (Lens')
 import Data.Map (Map, empty)
-import Data.Maybe (Maybe)
-import Data.Newtype (class Newtype, unwrap, wrap)
+import Data.Newtype (class Newtype, unwrap)
 import Data.Show.Generic (genericShow)
 import Data.Tuple (Tuple(Tuple))
 import FromData (class FromData)
@@ -52,7 +51,6 @@ import Serialization.Address
   )
 import Serialization.Hash
   ( Ed25519KeyHash
-  , ed25519KeyHashFromBech32
   )
 import ToData (class ToData)
 import Types.Datum (DatumHash)
@@ -105,12 +103,12 @@ instance DecodeJson PubKeyHash where
     (Left $ TypeMismatch "Expected object")
     (flip getField "getPubKeyHash" >=> decodeJson >>> map PubKeyHash)
 
-payPubKeyHash :: PaymentPubKey -> Maybe PaymentPubKeyHash
-payPubKeyHash (PaymentPubKey pk) = wrap <$> pubKeyHash pk
+-- payPubKeyHash :: PaymentPubKey -> Maybe PaymentPubKeyHash
+-- payPubKeyHash (PaymentPubKey pk) = wrap <$> pubKeyHash pk
 
-pubKeyHash :: PublicKey -> Maybe PubKeyHash
-pubKeyHash (PublicKey bech32) =
-  wrap <$> ed25519KeyHashFromBech32 bech32
+-- pubKeyHash :: PublicKey -> Maybe PubKeyHash
+-- pubKeyHash (PublicKey bech32) =
+--   wrap <$> ed25519KeyHashFromBech32 bech32
 
 payPubKeyVkey :: PaymentPubKey -> Vkey
 payPubKeyVkey (PaymentPubKey pk) = Vkey pk


### PR DESCRIPTION
Closes issue https://github.com/Plutonomicon/cardano-browser-tx/issues/236
- Because the `Address` from our wallet is the full address, using `addressBech32` provides the entire bech32string and not the public key bech32string. Subsequently, the call on `ed25519KeyHashFromBech32` doesn't work because it requires the public key version.
- To resolve I had to go via `StakeCredential` but this means we don't have a `pubKeyHash :: PublicKey -> PubKeyHash` function ATM (since `PublicKey` is a wrapper over the bech32string which is an alias for `String`). I've had to comment out relevant functions and lookups, thankfully I don't believe they affect Seabug.