### PR TITLE
Viet/seabug deployment test utxos at

### DIFF
--- a/examples/Seabug/Test.purs
+++ b/examples/Seabug/Test.purs
@@ -20,7 +20,7 @@ import Contract.Value (mkCurrencySymbol, mkTokenName)
 import Data.BigInt as BigInt
 import Data.UInt as UInt
 import Effect.Aff (launchAff_)
-import Seabug.Contract.MarketPlaceBuy (mkMarketplaceTx)
+import Seabug.Contract.MarketPlaceBuy (marketplaceBuy, mkMarketplaceTx)
 import Seabug.Types
   ( NftCollection(NftCollection)
   , NftData(NftData)
@@ -34,7 +34,12 @@ main :: Effect Unit
 main = launchAff_ $ do
   cfg <- defaultContractConfig
   runContract_ cfg $ do
-    UnbalancedTx { transaction } /\ _ <- mkMarketplaceTx =<< testNftData
+    log =<< map show testNftData
+    tdt <- testNftData
+    log $ show tdt
+    log "logged again"
+    -- marketplaceBuy tdt
+    UnbalancedTx { transaction } /\ _ <- mkMarketplaceTx tdt
     log =<<
       ( liftEffect
           <<< map
@@ -54,7 +59,7 @@ testNftData = do
     =<< hexToByteArray "cf0c1cbf47537f238f756fc1be191abf76009e1988910092184c4b7f"
   lockingScript <- liftContractM "`ScriptHash`"
     $ scriptHashFromBytes
-    =<< hexToByteArray "cf0c1cbf47537f238f756fc1be191abf76009e1988910092184c4b7f"
+    =<< hexToByteArray "6c1039b6973bb0e7ad42de5b16a691ede3e0265cd58caf070ff15ef3"
   daoScript <- liftContractM "`ScriptHash`"
     $ scriptHashFromBytes
     =<< hexToByteArray "9da8fa76a2a0f52aa5df10fb7b81f9afe4b20e9068b3f95fadc7477a"
@@ -78,3 +83,34 @@ testNftData = do
         , owner: wrap $ wrap kh
         }
     }
+
+-- (NftData { nftCollection: (NftCollection { author: (PaymentPubKeyHash (PubKeyHash (Ed25519KeyHash 3f3464650beb5324d0e463ebe81fbe1fd519b6438521e96d0d35bd75))),
+--  authorShare: (fromBigInt' (BigInt.fromString "1000")),
+--  collectionNftCs: (CurrencySymbol(byteArrayFromIntArrayUnsafe [207,12,28,191,71,83,127,35,143,117,111,193,190,25,26,191,118,0,158,25,136,145,0,146,24,76,75,127])),
+--   daoScript: (ValidatorHash (ScriptHash 9da8fa76a2a0f52aa5df10fb7b81f9afe4b20e9068b3f95fadc7477a)),
+--   daoShare: (fromBigInt' (BigInt.fromString "500")),
+--  lockLockup: fromString "5",
+-- lockLockupEnd: (Slot 5u)
+--    lockingScript: (ValidatorHash (ScriptHash 6c1039b6973bb0e7ad42de5b16a691ede3e0265cd58caf070ff15ef3)) }),
+--    nftId: (NftId { collectionNftTn: (TokenName(byteArrayFromIntArrayUnsafe [78,70,84,45,49,45,49])),
+--    owner: (PaymentPubKeyHash (PubKeyHash (Ed25519KeyHash 3f3464650beb5324d0e463ebe81fbe1fd519b6438521e96d0d35bd75))),
+--    price: (fromBigInt' (BigInt.fromString "100000000")) }) })
+
+-- let depositParams = NftData
+--     { nftData'nftCollection = NftCollection
+--       { nftCollection'collectionNftCs = "cf0c1cbf47537f238f756fc1be191abf76009e1988910092184c4b7f"
+--       , nftCollection'lockLockup = 5
+--       , nftCollection'lockLockupEnd = 5
+--       , nftCollection'lockingScript = "6c1039b6973bb0e7ad42de5b16a691ede3e0265cd58caf070ff15ef3"
+--           -- validatorHash $ lockValidator "cf0c1cbf47537f238f756fc1be191abf76009e1988910092184c4b7f" 5 5
+--       , nftCollection'author = PaymentPubKeyHash "3f3464650beb5324d0e463ebe81fbe1fd519b6438521e96d0d35bd75"
+--       , nftCollection'authorShare = toEnum 1000
+--       , nftCollection'daoScript = "9da8fa76a2a0f52aa5df10fb7b81f9afe4b20e9068b3f95fadc7477a" -- validatorHash $ daoValidator []
+--       , nftCollection'daoShare = toEnum 500
+--       }
+--     , nftData'nftId = NftId
+--       { nftId'collectionNftTn = "NFT-1-1"
+--       , nftId'price = toEnum 100_000_000
+--       , nftId'owner = PaymentPubKeyHash "3f3464650beb5324d0e463ebe81fbe1fd519b6438521e96d0d35bd75"
+--       }
+--     }

--- a/examples/Seabug/Test.purs
+++ b/examples/Seabug/Test.purs
@@ -20,7 +20,7 @@ import Contract.Value (mkCurrencySymbol, mkTokenName)
 import Data.BigInt as BigInt
 import Data.UInt as UInt
 import Effect.Aff (launchAff_)
-import Seabug.Contract.MarketPlaceBuy (marketplaceBuy, mkMarketplaceTx)
+import Seabug.Contract.MarketPlaceBuy (mkMarketplaceTx)
 import Seabug.Types
   ( NftCollection(NftCollection)
   , NftData(NftData)
@@ -34,12 +34,7 @@ main :: Effect Unit
 main = launchAff_ $ do
   cfg <- defaultContractConfig
   runContract_ cfg $ do
-    log =<< map show testNftData
-    tdt <- testNftData
-    log $ show tdt
-    log "logged again"
-    -- marketplaceBuy tdt
-    UnbalancedTx { transaction } /\ _ <- mkMarketplaceTx tdt
+    UnbalancedTx { transaction } /\ _ <- mkMarketplaceTx =<< testNftData
     log =<<
       ( liftEffect
           <<< map
@@ -59,7 +54,7 @@ testNftData = do
     =<< hexToByteArray "cf0c1cbf47537f238f756fc1be191abf76009e1988910092184c4b7f"
   lockingScript <- liftContractM "`ScriptHash`"
     $ scriptHashFromBytes
-    =<< hexToByteArray "6c1039b6973bb0e7ad42de5b16a691ede3e0265cd58caf070ff15ef3"
+    =<< hexToByteArray "cf0c1cbf47537f238f756fc1be191abf76009e1988910092184c4b7f"
   daoScript <- liftContractM "`ScriptHash`"
     $ scriptHashFromBytes
     =<< hexToByteArray "9da8fa76a2a0f52aa5df10fb7b81f9afe4b20e9068b3f95fadc7477a"
@@ -83,34 +78,3 @@ testNftData = do
         , owner: wrap $ wrap kh
         }
     }
-
--- (NftData { nftCollection: (NftCollection { author: (PaymentPubKeyHash (PubKeyHash (Ed25519KeyHash 3f3464650beb5324d0e463ebe81fbe1fd519b6438521e96d0d35bd75))),
---  authorShare: (fromBigInt' (BigInt.fromString "1000")),
---  collectionNftCs: (CurrencySymbol(byteArrayFromIntArrayUnsafe [207,12,28,191,71,83,127,35,143,117,111,193,190,25,26,191,118,0,158,25,136,145,0,146,24,76,75,127])),
---   daoScript: (ValidatorHash (ScriptHash 9da8fa76a2a0f52aa5df10fb7b81f9afe4b20e9068b3f95fadc7477a)),
---   daoShare: (fromBigInt' (BigInt.fromString "500")),
---  lockLockup: fromString "5",
--- lockLockupEnd: (Slot 5u)
---    lockingScript: (ValidatorHash (ScriptHash 6c1039b6973bb0e7ad42de5b16a691ede3e0265cd58caf070ff15ef3)) }),
---    nftId: (NftId { collectionNftTn: (TokenName(byteArrayFromIntArrayUnsafe [78,70,84,45,49,45,49])),
---    owner: (PaymentPubKeyHash (PubKeyHash (Ed25519KeyHash 3f3464650beb5324d0e463ebe81fbe1fd519b6438521e96d0d35bd75))),
---    price: (fromBigInt' (BigInt.fromString "100000000")) }) })
-
--- let depositParams = NftData
---     { nftData'nftCollection = NftCollection
---       { nftCollection'collectionNftCs = "cf0c1cbf47537f238f756fc1be191abf76009e1988910092184c4b7f"
---       , nftCollection'lockLockup = 5
---       , nftCollection'lockLockupEnd = 5
---       , nftCollection'lockingScript = "6c1039b6973bb0e7ad42de5b16a691ede3e0265cd58caf070ff15ef3"
---           -- validatorHash $ lockValidator "cf0c1cbf47537f238f756fc1be191abf76009e1988910092184c4b7f" 5 5
---       , nftCollection'author = PaymentPubKeyHash "3f3464650beb5324d0e463ebe81fbe1fd519b6438521e96d0d35bd75"
---       , nftCollection'authorShare = toEnum 1000
---       , nftCollection'daoScript = "9da8fa76a2a0f52aa5df10fb7b81f9afe4b20e9068b3f95fadc7477a" -- validatorHash $ daoValidator []
---       , nftCollection'daoShare = toEnum 500
---       }
---     , nftData'nftId = NftId
---       { nftId'collectionNftTn = "NFT-1-1"
---       , nftId'price = toEnum 100_000_000
---       , nftId'owner = PaymentPubKeyHash "3f3464650beb5324d0e463ebe81fbe1fd519b6438521e96d0d35bd75"
---       }
---     }

--- a/src/Contract/Address.purs
+++ b/src/Contract/Address.purs
@@ -36,8 +36,8 @@ import QueryM
   , ownPubKeyHash
   ) as QueryM
 import Scripts
-  ( typedValidatorAddress
-  , typedValidatorBaseAddress
+  ( typedValidatorBaseAddress
+  , typedValidatorEnterpriseAddress
   , validatorHashAddress
   , validatorHashBaseAddress
   ) as Scripts

--- a/src/Contract/Scripts.purs
+++ b/src/Contract/Scripts.purs
@@ -32,8 +32,8 @@ import QueryM
   ) as ExportQueryM
 import QueryM (applyArgs) as QueryM
 import Scripts
-  ( typedValidatorAddress
-  , typedValidatorBaseAddress
+  ( typedValidatorBaseAddress
+  , typedValidatorEnterpriseAddress
   , validatorHashAddress
   , validatorHashBaseAddress
   , scriptHash

--- a/src/Scripts.purs
+++ b/src/Scripts.purs
@@ -20,20 +20,11 @@ import QueryM (QueryM, hashScript)
 import Serialization.Address
   ( Address
   , BaseAddress
-  , ByronAddress
-  , EnterpriseAddress
-  , PointerAddress
-  , RewardAddress
   , NetworkId
   , addressFromBytes
   , baseAddressFromBytes
   , baseAddressToAddress
-  , enterpriseAddressFromBytes
-  , byronAddressFromBytes
   , scriptHashCredential
-  , pointerAddressFromBytes
-  , rewardAddress
-  , rewardAddressFromBytes
   , scriptAddress
   , enterpriseAddressToAddress
   , enterpriseAddress

--- a/src/Types/TypedTxOut.purs
+++ b/src/Types/TypedTxOut.purs
@@ -33,7 +33,7 @@ import Data.Show.Generic (genericShow)
 import FromData (class FromData, fromData)
 import Helpers (liftM)
 import QueryM (QueryM, getDatumByHash)
-import Scripts (typedValidatorAddress)
+import Scripts (typedValidatorEnterpriseAddress)
 import Serialization.Address (Address, NetworkId)
 import ToData (class ToData, toData)
 import Types.Datum (Datum(Datum), DatumHash, datumHash)
@@ -171,7 +171,9 @@ mkTypedTxOut
   -> Maybe (TypedTxOut a b)
 mkTypedTxOut networkId typedVal dt amount = do
   dHash <- datumHash $ Datum $ toData dt
-  let address = typedValidatorAddress networkId typedVal
+  -- FIX ME: This is hardcoded to enterprise address, it seems like Plutus'
+  -- "validatorAddress" also currently doesn't accoutn for staking.
+  let address = typedValidatorEnterpriseAddress networkId typedVal
   pure $ mkTypedTxOut' (wrap { address, amount, data_hash: pure dHash }) dt
   where
   mkTypedTxOut'
@@ -206,7 +208,7 @@ checkValidatorAddress
   -> Address
   -> m (Either TypeCheckError Unit)
 checkValidatorAddress networkId typedVal actualAddr = runExceptT do
-  let expectedAddr = typedValidatorAddress networkId typedVal
+  let expectedAddr = typedValidatorEnterpriseAddress networkId typedVal
   unless (expectedAddr == actualAddr)
     $ throwError
     $ WrongValidatorAddress expectedAddr actualAddr


### PR DESCRIPTION
Closes https://github.com/Plutonomicon/cardano-browser-tx/issues/243
- Fix for `typedValidatorAddress` by removing it (since it goes via a `BaseAddress`, redefining it to be `typedValidatorBaseAddress` to be clear). What we need is to go via an `EnterpriseAddress`, hence the creation of `typedValidatorEnterpriseAddress` - since an `EnterpriseAddress` doesn't care about stake credentials.
- In fact, Plutus' `validatorAddress` function works on `scriptHashAddress` found here: https://playground.plutus.iohkdev.io/doc/haddock/plutus-ledger-api/html/src/Plutus.V1.Ledger.Address.html#scriptHashAddress which also sets the stake credential to `Nothing` for now. So I believe it's safe to replace all instances of `typedValidatorAddress` in the codebase by `typedValidatorEnterpriseAddress`.
- I've separated the commits so we can merge the fix into `master`