### PR TITLE
Get Seabug metadata

### DIFF
--- a/examples/nami/Pkh2Pkh.purs
+++ b/examples/nami/Pkh2Pkh.purs
@@ -89,6 +89,8 @@ main = launchAff_ $ do
     , usedTxOuts
     , networkId: TestnetId
     , slotConfig: defaultSlotConfig
+    -- unused
+    , projectId: ""
     }
   liftEffect $ Console.log $ show txId
 

--- a/examples/nami/Simple.purs
+++ b/examples/nami/Simple.purs
@@ -42,6 +42,8 @@ main = launchAff_ $ do
     , usedTxOuts
     , networkId: TestnetId
     , slotConfig: defaultSlotConfig
+    -- unused
+    , projectId: ""
     }
   where
   walletActions :: QueryM Unit

--- a/packages.dhall
+++ b/packages.dhall
@@ -138,6 +138,7 @@ let additions =
             , "foldable-traversable"
             , "foreign-object"
             , "free"
+            , "http-methods"
             , "integers"
             , "lists"
             , "maybe"

--- a/packages.dhall
+++ b/packages.dhall
@@ -138,7 +138,6 @@ let additions =
             , "foldable-traversable"
             , "foreign-object"
             , "free"
-            , "http-methods"
             , "integers"
             , "lists"
             , "maybe"

--- a/spago.dhall
+++ b/spago.dhall
@@ -25,6 +25,7 @@ You can edit this file as you like.
   , "foreign"
   , "foreign-object"
   , "gen"
+  , "http-methods"
   , "identity"
   , "integers"
   , "lattice"

--- a/src/Contract/Monad.purs
+++ b/src/Contract/Monad.purs
@@ -185,6 +185,8 @@ defaultContractConfig = do
     , usedTxOuts
     , networkId: TestnetId
     , slotConfig: Interval.defaultSlotConfig
+    -- Will update at the use site
+    , projectId: ""
     }
 
 -- | Same as `defaultContractConfig` but lifted into `Contract`.

--- a/src/Contract/Value.purs
+++ b/src/Contract/Value.purs
@@ -9,8 +9,12 @@ module Contract.Value
 
 import Prelude
 import Contract.Monad (Contract)
+import Data.Argonaut (class DecodeJson)
+import Data.Either (hush)
 import Data.Maybe (Maybe)
 import Data.Newtype (wrap)
+import Data.Tuple.Nested (type (/\))
+import QueryM (getAssetMetadata) as QueryM
 import Scripts (scriptCurrencySymbol) as Scripts
 import Types.Scripts (MintingPolicy)
 import Types.Value
@@ -61,3 +65,10 @@ import Types.Value
 
 scriptCurrencySymbol :: MintingPolicy -> Contract (Maybe Value.CurrencySymbol)
 scriptCurrencySymbol = wrap <<< Scripts.scriptCurrencySymbol
+
+getAssetMetadata
+  :: forall (a :: Type)
+   . DecodeJson a
+  => Value.CurrencySymbol /\ Value.TokenName
+  -> Contract (Maybe a)
+getAssetMetadata = wrap <<< map hush <<< QueryM.getAssetMetadata

--- a/src/QueryM.purs
+++ b/src/QueryM.purs
@@ -10,6 +10,7 @@ module QueryM
   , ListenerSet
   , OgmiosListeners
   , OgmiosWebSocket
+  , ProjectId
   , QueryConfig
   , QueryM
   , ServerConfig
@@ -174,7 +175,10 @@ type QueryConfig =
   , usedTxOuts :: UsedTxOuts
   , networkId :: NetworkId
   , slotConfig :: SlotConfig
+  , projectId :: ProjectId
   }
+
+type ProjectId = String
 
 type QueryM (a :: Type) = ReaderT QueryConfig Aff a
 

--- a/src/QueryM.purs
+++ b/src/QueryM.purs
@@ -21,6 +21,7 @@ module QueryM
   , applyArgs
   , blake2bHash
   , calculateMinFee
+  , getAssetMetadata
   , cancelFetchBlocksRequest
   , datumFilterAddHashesRequest
   , datumFilterGetHashesRequest

--- a/src/QueryM.purs
+++ b/src/QueryM.purs
@@ -49,7 +49,6 @@ module QueryM
   ) where
 
 import Prelude
-import Undefined
 
 import Aeson as Aeson
 import Affjax as Affjax

--- a/test/AffInterface.purs
+++ b/test/AffInterface.purs
@@ -66,6 +66,8 @@ testUtxosAt testAddr = do
       , usedTxOuts
       , networkId: TestnetId
       , slotConfig: defaultSlotConfig
+      -- unused
+      , projectId: ""
       }
 
 testGetChainTip :: Aff Unit
@@ -82,6 +84,8 @@ testGetChainTip = do
     , usedTxOuts
     , networkId: TestnetId
     , slotConfig: defaultSlotConfig
+    -- unused
+    , projectId: ""
     }
 
 testFromOgmiosAddress :: OgmiosAddress -> Aff Unit


### PR DESCRIPTION
Partially closes #239 as I haven't updated the query endpoint yet with this. This is most of the work to get the metadata (from blockfrost) though, including the HTTP call and JSON decoding for `SeabugMetadata`

Since we are in a massive time crunch, this was hacked together rather quickly and I've made several assumptions, including:

- this will only ever be called on the testnet
- all `TokenName`s are ASCII