### PR TITLE
More Seabug fixes (`hashData`, fixing vkey witnesses)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ run-testnet-node:
 	  -e NETWORK=testnet \
 	  -v "$$PWD"/.node/socket:/ipc \
 	  -v "$$PWD"/.node/data:/data \
-	  inputoutput/cardano-node:1.31.0
+	  inputoutput/cardano-node:1.34.0
 
 run-testnet-ogmios:
 	ogmios \

--- a/examples/Seabug/Contract/MarketPlaceBuy.purs
+++ b/examples/Seabug/Contract/MarketPlaceBuy.purs
@@ -37,6 +37,7 @@ import Contract.Transaction
   , UnbalancedTx
   , balanceTx
   , finalizeTx
+  , signTransactionBytes
   )
 import Contract.TxConstraints
   ( TxConstraints
@@ -85,8 +86,10 @@ marketplaceBuy nftData = do
     liftedM "marketplaceBuy: Cannot attach datums and redeemer"
       (finalizeTx balancedTx datums redeemers)
   log "marketplaceBuy: Datums and redeemer attached"
+  signedTxCbor <- liftedM "Failed to sign transaction" $
+    signTransactionBytes txCbor
   -- Submit transaction:
-  transactionHash <- wrap $ submit txCbor
+  transactionHash <- wrap $ submit signedTxCbor
   -- -- Submit balanced tx:
   log $ "marketplaceBuy: Transaction successfully submitted with hash: "
     <> show transactionHash

--- a/server/src/Api/Handlers.hs
+++ b/server/src/Api/Handlers.hs
@@ -19,6 +19,7 @@ import Cardano.Ledger.Alonzo.Language (Language (PlutusV1))
 import Cardano.Ledger.Alonzo.Tx qualified as Tx
 import Cardano.Ledger.Alonzo.TxWitness qualified as TxWitness
 import Cardano.Ledger.Crypto (StandardCrypto)
+import Cardano.Ledger.SafeHash qualified as SafeHash
 import Codec.CBOR.Read (deserialiseFromBytes)
 import Control.Lens
 import Control.Monad.Catch (throwM)
@@ -76,7 +77,7 @@ hashData (HashDataRequest datum) = do
   decodedDatum <-
     throwDecodeErrorWithMessage "Failed to decode Datum" $
       decodeCborDatum datum
-  pure . HashedData . encodeCborText . Cbor.serializeEncoding . Cbor.toCBOR $
+  pure . HashedData . SafeHash.originalBytes $
     Data.hashData decodedDatum
 
 throwDecodeErrorWithMessage :: forall (a :: Type). String -> Maybe a -> AppM a

--- a/server/src/Types.hs
+++ b/server/src/Types.hs
@@ -144,9 +144,10 @@ newtype HashDataRequest = HashDataRequest Cbor
   deriving stock (Show, Generic)
   deriving newtype (Eq, FromJSON, ToJSON)
 
-newtype HashedData = HashedData Cbor
+newtype HashedData = HashedData ByteString
   deriving stock (Show, Generic)
-  deriving newtype (Eq, FromJSON, ToJSON)
+  deriving newtype (Eq)
+  deriving (FromJSON, ToJSON) via JsonHexString
 
 -- Adapted from `plutus-apps` implementation
 -- rev. d637b1916522e4ec20b719487a8a2e066937aceb
@@ -244,7 +245,8 @@ instance Docs.ToSample HashedData where
     ]
     where
       -- Fix this with an actual hash
-      exampleData = Cbor $ mconcat
+      exampleData :: ByteString
+      exampleData = mconcat
         [ "84a300818258205d677265fa5bb21ce6d8c7502aca70b93"
         , "16d10e958611f3c6b758f65ad9599960001818258390030"
         , "fb3b8539951e26f034910a5a37f22cb99d94d1d409f69dd"
@@ -284,6 +286,7 @@ instance Docs.ToSample FinalizedTransaction where
     [ ("The output is CBOR-encoded Tx", exampleTx)
     ]
     where
+      exampleTx :: FinalizedTransaction
       exampleTx = FinalizedTransaction . Cbor $ mconcat
         [ "84a300818258205d677265fa5bb21ce6d8c7502aca70b93"
         , "16d10e958611f3c6b758f65ad9599960001818258390030"

--- a/server/test/Main.hs
+++ b/server/test/Main.hs
@@ -194,8 +194,8 @@ cborDatumFixture =
       ]
 
 hashedDatumFixture :: HashedData
-hashedDatumFixture = HashedData $
-  Cbor "5820961d7ebd383bef116ef9bcb527f1bc1a4587f819d4ec0e723fef5ab228ad1d8f"
+hashedDatumFixture = HashedData
+  "\150\GS~\189\&8;\239\DC1n\249\188\181'\241\188\SUBE\135\248\EM\212\236\SOr?\239Z\178(\173\GS\143"
 
 -- This is a known-good 'Tx AlonzoEra'
 cborTxFixture :: Cbor

--- a/src/Contract/Transaction.purs
+++ b/src/Contract/Transaction.purs
@@ -6,6 +6,7 @@ module Contract.Transaction
   , calculateMinFee
   , calculateMinFeeM
   , signTransaction
+  , signTransactionBytes
   , submitTransaction
   , finalizeTx
   , module BalanceTxError
@@ -33,9 +34,11 @@ import QueryM
   ( FinalizedTransaction
   , calculateMinFee
   , signTransaction
+  , signTransactionBytes
   , submitTransaction
   , finalizeTx
   ) as QueryM
+import Types.ByteArray (ByteArray)
 import Types.JsonWsp (OgmiosTxOut, OgmiosTxOutRef) as JsonWsp -- FIX ME: https://github.com/Plutonomicon/cardano-browser-tx/issues/200
 import Types.ScriptLookups
   ( MkUnbalancedTxError(..) -- A lot errors so will refrain from explicit names.
@@ -157,6 +160,10 @@ import Types.Datum (Datum)
 -- | Signs a `Transaction` with potential failure.
 signTransaction :: Transaction -> Contract (Maybe Transaction)
 signTransaction = wrap <<< QueryM.signTransaction
+
+-- | Signs a `Transaction` with potential failure
+signTransactionBytes :: ByteArray -> Contract (Maybe ByteArray)
+signTransactionBytes = wrap <<< QueryM.signTransactionBytes
 
 -- | Submits a `Transaction` with potential failure.
 submitTransaction :: Transaction -> Contract (Maybe TransactionHash)

--- a/src/QueryM.purs
+++ b/src/QueryM.purs
@@ -507,7 +507,8 @@ instance Json.DecodeJson HashedData where
     map HashedData <<<
       Json.caseJsonString (Left err) (note err <<< hexToByteArray)
     where
-    err = Json.TypeMismatch "Expected CborHex of hashed data"
+    err :: Json.JsonDecodeError
+    err = Json.TypeMismatch "Expected hex bytes (raw) of hashed data"
 
 hashData :: Datum -> QueryM (Maybe HashedData)
 hashData datum = do

--- a/src/QueryM.purs
+++ b/src/QueryM.purs
@@ -527,14 +527,7 @@ hashData datum = do
 
 -- | Hashes an Plutus-style Datum
 datumHash :: Datum -> QueryM (Maybe DatumHash)
-datumHash datum = do
-  mHd <- hashData datum
-  -- Remove the first two bytes because CBOR prepends which is in hexstring
-  -- ByteArray [88,32] ~ Hexstring "5820"
-  let
-    fixedH = mHd >>=
-      unwrap >>> byteArrayToIntArray >>> drop 2 >>> byteArrayFromIntArray
-  pure $ maybe Nothing (Just <<< Transaction.DataHash) fixedH
+datumHash = map (map (Transaction.DataHash <<< unwrap)) <<< hashData
 
 -- | Apply `PlutusData` arguments to any type isomorphic to `PlutusScript`,
 -- | returning an updated script with the provided arguments applied

--- a/src/QueryM.purs
+++ b/src/QueryM.purs
@@ -48,6 +48,7 @@ module QueryM
   , ownPubKeyHash
   , queryDatumCache
   , signTransaction
+  , signTransactionBytes
   , startFetchBlocksRequest
   , submitTransaction
   , underlyingWebSocket
@@ -293,6 +294,11 @@ signTransaction
   :: Transaction.Transaction -> QueryM (Maybe Transaction.Transaction)
 signTransaction tx = withMWalletAff $ case _ of
   Nami nami -> callNami nami $ \nw -> flip nw.signTx tx
+
+signTransactionBytes
+  :: ByteArray -> QueryM (Maybe ByteArray)
+signTransactionBytes tx = withMWalletAff $ case _ of
+  Nami nami -> callNami nami $ \nw -> flip nw.signTxBytes tx
 
 submitTransaction
   :: Transaction.Transaction -> QueryM (Maybe Transaction.TransactionHash)

--- a/src/Wallet.purs
+++ b/src/Wallet.purs
@@ -3,6 +3,7 @@ module Wallet
   , NamiWallet
   , Wallet(..)
   , mkNamiWalletAff
+  , dummySign
   ) where
 
 import Prelude


### PR DESCRIPTION
- Borrows from #267 to fix signing
- Signing in balancer has been removed (will fix fee endpoint instead to take number of extra key witnesses as a parameter)
- Node version bumped
- `hashData` has been fixed on both client and server