### PR TITLE
Viet/seabug deployment refactor, add `balanceAndSignTx` and related newtypes 

### DIFF
--- a/examples/Seabug/Contract/MarketPlaceBuy.purs
+++ b/examples/Seabug/Contract/MarketPlaceBuy.purs
@@ -10,6 +10,10 @@ import Contract.Address
   , payPubKeyHashBaseAddress
   )
 import Contract.ScriptLookups
+  ( UnattachedUnbalancedTx(UnattachedUnbalancedTx)
+  , mkUnbalancedTx
+  )
+import Contract.ScriptLookups
   ( mintingPolicy
   , otherScript
   , ownPaymentPubKeyHash
@@ -33,13 +37,10 @@ import Contract.PlutusData
 import Contract.ProtocolParameters.Alonzo (minAdaTxOut)
 import Contract.Scripts (typedValidatorEnterpriseAddress)
 import Contract.Transaction
-  ( TransactionInput
+  ( BalancedSignedTransaction(BalancedSignedTransaction)
   , TxOut
-  , UnbalancedTx
-  , balanceTx
-  , finalizeTx
-  , reindexSpentScriptRedeemers
-  , signTransactionBytes
+  , balanceAndSignTx
+  , submit
   )
 import Contract.TxConstraints
   ( TxConstraints
@@ -62,8 +63,6 @@ import Contract.Value
 import Data.Array (find) as Array
 import Data.BigInt (BigInt, fromInt)
 import Data.Map (insert, toUnfoldable)
-import QueryM (FinalizedTransaction(FinalizedTransaction))
-import QueryM.Submit (submit)
 import Seabug.MarketPlace (marketplaceValidator)
 import Seabug.MintingPolicy (mintingPolicy)
 import Seabug.Token (mkTokenName)
@@ -73,28 +72,23 @@ import Seabug.Types
   , NftData(NftData)
   , NftId(NftId)
   )
-import Types.ScriptLookups (mkUnbalancedTx')
-import Types.Transaction (Redeemer) as T
 
 marketplaceBuy :: NftData -> Contract Unit
 marketplaceBuy nftData = do
-  { unbalancedTx, datums, redeemersTxIns } /\ curr /\ newName <-
-    mkMarketplaceTx nftData
-  -- Balance unbalanced tx:
-  balancedTx <- liftedE' $ balanceTx unbalancedTx
-  log "marketplaceBuy: Transaction successfully balanced"
-  redeemers <- liftedE' $ reindexSpentScriptRedeemers balancedTx redeemersTxIns
-  log "marketplaceBuy: Redeemers reindexed returned"
-  -- Reattach datums and redeemer:
-  FinalizedTransaction txCbor <-
-    liftedM "marketplaceBuy: Cannot attach datums and redeemer"
-      (finalizeTx balancedTx datums redeemers)
-  log "marketplaceBuy: Datums and redeemer attached"
-  signedTxCbor <- liftedM "Failed to sign transaction" $
-    signTransactionBytes txCbor
-  -- Submit transaction:
-  transactionHash <- wrap $ submit signedTxCbor
-  -- -- Submit balanced tx:
+  UnattachedUnbalancedTx { unbalancedTx, datums, redeemersTxIns }
+    /\ curr
+    /\ newName <- mkMarketplaceTx nftData
+  -- `balanceAndSignTx` does the following:
+  -- 1) Balance a transaction
+  -- 2) Reindex `Spend` redeemers after finalising transaction inputs.
+  -- 3) Attach datums and redeemers to transaction.
+  -- 3) Sign tx, returning the Cbor-hex encoded `ByteArray`.
+  BalancedSignedTransaction { signedTxCbor } <- liftedM
+    "marketplaceBuy: Cannot balance, reindex redeemers, attach datums/redeemers\
+    \ and sign"
+    (balanceAndSignTx unbalancedTx datums redeemersTxIns)
+  -- Submit transaction using Cbor-hex encoded `ByteArray`
+  transactionHash <- submit signedTxCbor
   log $ "marketplaceBuy: Transaction successfully submitted with hash: "
     <> show transactionHash
   log $ "marketplaceBuy: Buy successful: " <> show (curr /\ newName)
@@ -106,12 +100,7 @@ marketplaceBuy nftData = do
 -- applied to arguments. See `Seabug.Token.policy`
 mkMarketplaceTx
   :: NftData
-  -> Contract
-       ( { unbalancedTx :: UnbalancedTx
-         , datums :: Array Datum
-         , redeemersTxIns :: Array (T.Redeemer /\ Maybe TransactionInput)
-         } /\ CurrencySymbol /\ TokenName
-       )
+  -> Contract (UnattachedUnbalancedTx /\ CurrencySymbol /\ TokenName)
 mkMarketplaceTx (NftData nftData) = do
   pkh <- liftedM "marketplaceBuy: Cannot get PaymentPubKeyHash"
     ownPaymentPubKeyHash
@@ -201,6 +190,8 @@ mkMarketplaceTx (NftData nftData) = do
               )
               (newNftValue <> coinToValue minAdaTxOut)
           ]
-  -- Created unbalanced tx which stripped datums and redeemers with tx inputs:
-  txDatumsRedeemerTxIns <- liftedE' $ wrap (mkUnbalancedTx' lookup constraints)
+  -- Created unbalanced tx which stripped datums and redeemers with tx inputs,
+  -- the datums and redeemers will be reattached using a server with redeemers
+  -- reindexed also.
+  txDatumsRedeemerTxIns <- liftedE' (mkUnbalancedTx lookup constraints)
   pure $ txDatumsRedeemerTxIns /\ curr /\ newName

--- a/examples/Seabug/Contract/MarketPlaceBuy.purs
+++ b/examples/Seabug/Contract/MarketPlaceBuy.purs
@@ -9,10 +9,7 @@ import Contract.Address
   , ownPaymentPubKeyHash
   , payPubKeyHashBaseAddress
   )
-import Contract.ScriptLookups
-  ( UnattachedUnbalancedTx(UnattachedUnbalancedTx)
-  , mkUnbalancedTx
-  )
+import Contract.ScriptLookups (UnattachedUnbalancedTx, mkUnbalancedTx)
 import Contract.ScriptLookups
   ( mintingPolicy
   , otherScript
@@ -75,9 +72,7 @@ import Seabug.Types
 
 marketplaceBuy :: NftData -> Contract Unit
 marketplaceBuy nftData = do
-  UnattachedUnbalancedTx { unbalancedTx, datums, redeemersTxIns }
-    /\ curr
-    /\ newName <- mkMarketplaceTx nftData
+  unattachedBalancedTx /\ curr /\ newName <- mkMarketplaceTx nftData
   -- `balanceAndSignTx` does the following:
   -- 1) Balance a transaction
   -- 2) Reindex `Spend` redeemers after finalising transaction inputs.
@@ -86,7 +81,7 @@ marketplaceBuy nftData = do
   BalancedSignedTransaction { signedTxCbor } <- liftedM
     "marketplaceBuy: Cannot balance, reindex redeemers, attach datums/redeemers\
     \ and sign"
-    (balanceAndSignTx unbalancedTx datums redeemersTxIns)
+    (balanceAndSignTx unattachedBalancedTx)
   -- Submit transaction using Cbor-hex encoded `ByteArray`
   transactionHash <- submit signedTxCbor
   log $ "marketplaceBuy: Transaction successfully submitted with hash: "

--- a/src/Contract/Transaction.purs
+++ b/src/Contract/Transaction.purs
@@ -250,18 +250,14 @@ balanceAndSignTx
   (UnattachedUnbalancedTx { unbalancedTx, datums, redeemersTxIns }) = do
   -- Balance unbalanced tx:
   balancedTx <- liftedE' $ balanceTx unbalancedTx
-  log "balanceAndSignTx: Transaction successfully balanced"
   let inputs = balancedTx ^. _body <<< _inputs
   redeemers <- liftedE' $ reindexSpentScriptRedeemers inputs redeemersTxIns
-  log "balanceAndSignTx: Redeemers reindexed returned"
   -- Reattach datums and redeemer:
   QueryM.FinalizedTransaction txCbor <-
     liftedM "balanceAndSignTx: Cannot attach datums and redeemer"
       (finalizeTx balancedTx datums redeemers)
-  log "balanceAndSignTx: Datums and redeemer attached"
   -- Sign the transaction returned as Cbor-hex encoded:
   signedTxCbor <- liftedM "balanceAndSignTx: Failed to sign transaction" $
     signTransactionBytes txCbor
-  log "balanceAndSignTx: Transaction signed"
   pure $ pure $ BalancedSignedTransaction
     { transaction: balancedTx, signedTxCbor }

--- a/src/Contract/Transaction.purs
+++ b/src/Contract/Transaction.purs
@@ -178,7 +178,7 @@ signTransactionBytes :: ByteArray -> Contract (Maybe ByteArray)
 signTransactionBytes = wrap <<< QueryM.signTransactionBytes
 
 -- | Submits a Cbor-hex encoded transaction, which is the output of
--- | `signTransactionBytes` or  `balanceAndSignTx`
+-- | `signTransactionBytes` or `balanceAndSignTx`
 submit :: ByteArray -> Contract String
 submit = wrap <<< Submit.submit
 
@@ -249,17 +249,17 @@ balanceAndSignTx
 balanceAndSignTx unbalancedTx datums redeemersTxIns = do
   -- Balance unbalanced tx:
   balancedTx <- liftedE' $ balanceTx unbalancedTx
-  log "Transaction successfully balanced"
+  log "balanceAndSignTx: Transaction successfully balanced"
   redeemers <- liftedE' $ reindexSpentScriptRedeemers balancedTx redeemersTxIns
-  log "Redeemers reindexed returned"
+  log "balanceAndSignTx: Redeemers reindexed returned"
   -- Reattach datums and redeemer:
   QueryM.FinalizedTransaction txCbor <-
-    liftedM "Cannot attach datums and redeemer"
+    liftedM "balanceAndSignTx: Cannot attach datums and redeemer"
       (finalizeTx balancedTx datums redeemers)
-  log "Datums and redeemer attached"
+  log "balanceAndSignTx: Datums and redeemer attached"
   -- Sign the transaction returned as Cbor-hex encoded:
-  signedTxCbor <- liftedM "Failed to sign transaction" $
+  signedTxCbor <- liftedM "balanceAndSignTx: Failed to sign transaction" $
     signTransactionBytes txCbor
-  log "Transaction signed"
+  log "balanceAndSignTx: Transaction signed"
   pure $ pure $ BalancedSignedTransaction
     { transaction: balancedTx, signedTxCbor }

--- a/src/Contract/Transaction.purs
+++ b/src/Contract/Transaction.purs
@@ -52,6 +52,7 @@ import ReindexRedeemers
   ( ReindexErrors(CannotGetTxOutRefIndexForRedeemer)
   ) as ReindexRedeemersExport
 import Types.JsonWsp (OgmiosTxOut, OgmiosTxOutRef) as JsonWsp -- FIX ME: https://github.com/Plutonomicon/cardano-browser-tx/issues/200
+import Types.ScriptLookups (UnattachedUnbalancedTx(UnattachedUnbalancedTx))
 import Types.ScriptLookups
   ( MkUnbalancedTxError(..) -- A lot errors so will refrain from explicit names.
   , mkUnbalancedTx
@@ -242,11 +243,10 @@ instance Show BalancedSignedTransaction where
 -- | logging and more importantly, the `ByteArray` to be used with `Submit` to
 -- | submit  the transaction.
 balanceAndSignTx
-  :: UnbalancedTx
-  -> Array Datum
-  -> Array (Transaction.Redeemer /\ Maybe Transaction.TransactionInput)
+  :: UnattachedUnbalancedTx
   -> Contract (Maybe BalancedSignedTransaction)
-balanceAndSignTx unbalancedTx datums redeemersTxIns = do
+balanceAndSignTx
+  (UnattachedUnbalancedTx { unbalancedTx, datums, redeemersTxIns }) = do
   -- Balance unbalanced tx:
   balancedTx <- liftedE' $ balanceTx unbalancedTx
   log "balanceAndSignTx: Transaction successfully balanced"

--- a/src/Contract/Transaction.purs
+++ b/src/Contract/Transaction.purs
@@ -33,7 +33,6 @@ import Data.Maybe (Maybe)
 import Data.Newtype (class Newtype, wrap)
 import Data.Show.Generic (genericShow)
 import Data.Tuple.Nested (type (/\))
-import Effect.Class.Console (log)
 import QueryM
   ( FeeEstimate(FeeEstimate)
   , ClientError(..) -- implicit as this error list will likely increase.

--- a/src/ReindexRedeemers.purs
+++ b/src/ReindexRedeemers.purs
@@ -12,7 +12,6 @@ import Data.Array (elemIndex)
 import Data.BigInt (fromInt)
 import Data.Either (Either(Right), note)
 import Data.Generic.Rep (class Generic)
-import Data.Lens.Getter ((^.))
 import Data.Maybe (Maybe(Just))
 import Data.Show.Generic (genericShow)
 import Data.Traversable (traverse)
@@ -21,12 +20,7 @@ import Helpers (liftEither)
 import QueryM (QueryM)
 import Types.RedeemerTag (RedeemerTag(Spend))
 import Types.Transaction (Redeemer(Redeemer)) as T
-import Types.Transaction
-  ( Transaction
-  , TransactionInput
-  , _body
-  , _inputs
-  )
+import Types.Transaction (TransactionInput)
 
 -- | The only error should be impossible but we keep this here in case the user
 -- | decides to call this function at some point where inputs have been
@@ -42,11 +36,10 @@ instance Show ReindexErrors where
 -- | reindex the redeemers with such inputs. This must be crucially called after
 -- | balancing when all inputs are in place so they cannot be reordered.
 reindexSpentScriptRedeemers
-  :: Transaction
+  :: Array TransactionInput
   -> Array (T.Redeemer /\ Maybe TransactionInput)
   -> QueryM (Either ReindexErrors (Array T.Redeemer))
-reindexSpentScriptRedeemers balancedTx redeemersTxIns = runExceptT do
-  let inputs = balancedTx ^. _body <<< _inputs
+reindexSpentScriptRedeemers inputs redeemersTxIns = runExceptT do
   liftEither $ traverse (reindex inputs) redeemersTxIns
   where
   reindex

--- a/src/Types/UnbalancedTransaction.purs
+++ b/src/Types/UnbalancedTransaction.purs
@@ -87,6 +87,7 @@ newtype ScriptOutput = ScriptOutput
 
 derive instance Newtype ScriptOutput _
 derive instance Generic ScriptOutput _
+derive newtype instance Eq ScriptOutput
 
 instance Show ScriptOutput where
   show = genericShow
@@ -238,6 +239,7 @@ newtype UnbalancedTx = UnbalancedTx
 
 derive instance Newtype UnbalancedTx _
 derive instance Generic UnbalancedTx _
+derive newtype instance Eq UnbalancedTx
 
 instance Show UnbalancedTx where
   show = genericShow


### PR DESCRIPTION
- Created from https://github.com/Plutonomicon/cardano-browser-tx/tree/viet/seabug-deployment-fixes
- Made the "temporary" `balanceTx'` the main one (which now returns `UnattachedUnbalancedTx` newtype), because even if we eventually attach datums with CSL, we still need the redeemers (at the very least) to reattach after balancing. I kept this separate from `balanceAndSignTx` (see below).
- ^ So `balancedTx'` and `balanceTx` have swapped names unless it's unclear.
- `balanceAndSignTx`  balances the tx, reindex `Spend` redeemers, attaches datums and redeemers and signs returning the `BalancedSignedTransaction` newtype.
- Removed `submitTransaction :: Transaction -> Contract (Maybe TransactionHash)` from `Contract` API to prevent confusion.
- Finally, the user just needs to submit.
- Any feedback would be great, especially better names.

I was thinking of changing the following names (given the logic in `balanceAndSignTx`):
1) `QueryM.FinalizedTransaction` -> `QueryM.AttachedTransaction` (maybe rename `finalizeTx` -> `attachDatumsRedeemersToTx`?)
2) `BalancedSignedTransaction` -> `FinalizedTransaction` (maybe rename `balanceAndSignTx` -> `finalizeTx`?)
Any thoughts?